### PR TITLE
feat: add az phewas v5 trait curation

### DIFF
--- a/mappings/disease/manual_string.tsv
+++ b/mappings/disease/manual_string.tsv
@@ -25357,3 +25357,1726 @@ ClinVar		disease	ZNF711-Related X-linked Mental Retardation	http://www.orpha.net
 ClinVar		disease	Zonular pulverulent cataract 3	http://www.orpha.net/ORDO/Orphanet_91492	Gautier Koscielny	2017-06-06 12:00:00
 ClinVar		disease	ZTTK SYNDROME	http://www.orpha.net/ORDO/Orphanet_102283	Gautier Koscielny	2017-06-06 12:00:00
 ClinVar		disease	Zunich neuroectodermal syndrome	http://www.orpha.net/ORDO/Orphanet_3474	Gautier Koscielny	2017-06-06 12:00:00
+AstraZeneca PheWAS Portal		disease	20002#1297#muscle|soft tissue problem	http://www.ebi.ac.uk/efo/EFO_0002970	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1297#muscle|soft tissue problem	http://www.ebi.ac.uk/efo/EFO_0009470	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#K631#Perforation of intestine (nontraumatic)	http://www.ebi.ac.uk/efo/EFO_1000987	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z800#Family history of malignant neoplasm of digestive organs	http://www.ebi.ac.uk/efo/EFO_0009640	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4700#Age cataract diagnosed	http://purl.obolibrary.org/obo/MONDO_0005129	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4119#Ankle spacing width (right)	http://www.ebi.ac.uk/efo/EFO_0004324	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H35#Other retinal disorders	http://www.ebi.ac.uk/efo/EFO_0003839	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H33#Retinal detachments and breaks	http://www.ebi.ac.uk/efo/EFO_0005773	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Z400#Prophylactic surgery for risk-factors related to malignant neoplasms	http://www.ebi.ac.uk/efo/EFO_0009580	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C66#Malignant neoplasm of ureter	http://www.ebi.ac.uk/efo/EFO_0003844	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1193#renal failure requiring dialysis	http://www.ebi.ac.uk/efo/EFO_1002048	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23484#NMR Cholesterol in Chylomicrons and Extremely Large VLDL	http://www.ebi.ac.uk/efo/EFO_0021898	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30670#Urea	http://www.ebi.ac.uk/efo/EFO_0011005	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23517#NMR Total Lipids in Very Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022156	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5262#Intra-ocular pressure corneal-compensated (left)	http://www.ebi.ac.uk/efo/EFO_0004695	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131261#Source of report of H91 other hearing loss	http://www.ebi.ac.uk/efo/EFO_0004238	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L409#Psoriasis unspecified	http://www.ebi.ac.uk/efo/EFO_0000676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Z80-Z99#Z80-Z99 Persons with potential health hazards related to family and personal history and certain conditions influencing health status	http://www.ebi.ac.uk/efo/EFO_0004542	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23462#NMR Glycine	http://www.ebi.ac.uk/efo/EFO_0009767	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z720#Tobacco use	http://www.ebi.ac.uk/efo/EFO_0003768	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1371#sarcoidosis	http://purl.obolibrary.org/obo/MONDO_0019338	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block M05-M14#M05-M14 Inflammatory polyarthropathies	http://purl.obolibrary.org/obo/NCIT_C197299	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23580#NMR Cholesterol to Total Lipids in Chylomicrons and Extremely Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022232	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23577#NMR Free Cholesterol in Small HDL	http://www.ebi.ac.uk/efo/EFO_0022270	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesteryl Esters to Total Lipids in VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022253	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131793#Source of report of L71 rosacea	http://www.ebi.ac.uk/efo/EFO_1000760	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z874#Personal history of diseases of the genitourinary system	http://www.ebi.ac.uk/efo/EFO_0009663	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C505#Malignant neoplasm: Lower-outer quadrant of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30150#Eosinophill count	http://www.ebi.ac.uk/efo/EFO_0004842	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block E20-E35#E20-E35 Disorders of other endocrine glands	http://www.ebi.ac.uk/efo/EFO_0001379	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M8587#Other specified disorders of bone density and structure Ankle and foot	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23251#Arm tissue fat percentage (left)	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z80#Family history of malignant neoplasm	http://www.ebi.ac.uk/efo/EFO_0009640	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	2217#Age started wearing glasses or contact lenses	http://purl.obolibrary.org/obo/MONDO_0004892	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C90#Multiple myeloma and malignant plasma cell neoplasms	http://www.ebi.ac.uk/efo/EFO_0001378	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I45#Other conduction disorders	http://www.ebi.ac.uk/efo/EFO_0005137	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8441#Serous cystadenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0006387	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1460#rectal or colon adenoma|polyps	http://www.ebi.ac.uk/efo/EFO_1000633	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I95#Hypotension	http://www.ebi.ac.uk/efo/EFO_0005251	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23607#NMR Free Cholesterol to Total Lipids in Very Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022290	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C946#Myelodysplastic and myeloproliferative disease not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130659#Source of report of D69 purpura and other haemorrhagic conditions	http://purl.obolibrary.org/obo/HP_0000979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D730#Hyposplenism	http://www.ebi.ac.uk/efo/EFO_0009002	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1449#myeloproliferative disorder	http://www.ebi.ac.uk/efo/EFO_0004251	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30680#Calcium	http://www.ebi.ac.uk/efo/EFO_0004838	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23542#NMR Free Cholesterol in Medium LDL	http://www.ebi.ac.uk/efo/EFO_0022268	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R91#Abnormal findings on diagnostic imaging of lung	http://www.ebi.ac.uk/efo/EFO_0003818	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3143#Ankle spacing width	http://www.ebi.ac.uk/efo/EFO_0004324	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K57#Diverticular disease of intestine	http://www.ebi.ac.uk/efo/EFO_1001460	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q27#Other congenital malformations of peripheral vascular system	http://purl.obolibrary.org/obo/HP_0002597	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3581#Age at menopause (last menstrual period)	http://www.ebi.ac.uk/efo/EFO_0004704	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23450#NMR Docosahexaenoic Acid	http://www.ebi.ac.uk/efo/EFO_0007761	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23479#NMR Albumin	http://www.ebi.ac.uk/efo/EFO_0004535	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C001#Malignant neoplasm: External lower lip	http://www.ebi.ac.uk/efo/EFO_1001019	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R600#Localized oedema	http://www.ebi.ac.uk/efo/EFO_0009373	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23498#NMR Cholesterol in Large VLDL	http://www.ebi.ac.uk/efo/EFO_0021902	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H354#Peripheral retinal degeneration	http://purl.obolibrary.org/obo/MONDO_0004580	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25344#Mean ICVF in middle cerebellar peduncle on FA skeleton	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D471#Chronic myeloproliferative disease	http://www.ebi.ac.uk/efo/EFO_0002428	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block K80-K87#K80-K87 Disorders of gallbladder| biliary tract and pancreas	http://www.ebi.ac.uk/efo/EFO_0003832	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#ChapterX#Chapter X Diseases of the respiratory system	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N40#Hyperplasia of prostate	http://www.ebi.ac.uk/efo/EFO_0009602	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	120007#Ever had diabetes Type I or Type II	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D693#Idiopathic thrombocytopenic purpura	http://purl.obolibrary.org/obo/MONDO_0043768	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I739#Peripheral vascular disease unspecified	http://www.ebi.ac.uk/efo/EFO_0003875	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block M80-M85#M80-M85 Disorders of bone density and structure	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30720#Cystatin C	http://www.ebi.ac.uk/efo/EFO_0004617	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#J939#Pneumothorax unspecified	http://purl.obolibrary.org/obo/MONDO_0002076	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I251#Atherosclerotic heart disease	http://www.ebi.ac.uk/efo/EFO_0009783	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L85#Other epidermal thickening	http://purl.obolibrary.org/obo/HP_0011368	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#J841#Other interstitial pulmonary diseases with fibrosis	http://www.ebi.ac.uk/efo/EFO_0009448	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter III#Chapter III Diseases of the blood and blood-forming organs and certain disorders involving the immune mechanism	http://www.ebi.ac.uk/efo/EFO_0000540	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131529#Source of report of J84 other interstitial pulmonary diseases	http://www.ebi.ac.uk/efo/EFO_0004244	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N18#Chronic kidney disease	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D04#Carcinoma in situ of skin	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I10#Essential (primary) hypertension	http://www.ebi.ac.uk/efo/EFO_0000479	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q120#Congenital cataract	http://purl.obolibrary.org/obo/HP_0000519	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C93#Monocytic leukaemia	http://purl.obolibrary.org/obo/MONDO_0004600	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#Block C51-C58#C51-C58 Malignant neoplasms of female genital organs	http://www.ebi.ac.uk/efo/EFO_1001331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8246#Neuroendocrine carcinoma	http://purl.obolibrary.org/obo/MONDO_0002120	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	6152#7#Blood clot in the lung	http://purl.obolibrary.org/obo/HP_0002204	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23632#NMR Free Cholesterol to Total Lipids in Very Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022288	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131591#Source of report of K25 gastric ulcer	http://www.ebi.ac.uk/efo/EFO_0009454	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23416#NMR Cholesteryl Esters in VLDL	http://www.ebi.ac.uk/efo/EFO_0022182	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23543#NMR Triglycerides in Medium LDL	http://www.ebi.ac.uk/efo/EFO_0022322	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I519#Heart disease unspecified	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4194#Pulse rate	http://www.ebi.ac.uk/efo/EFO_0004326	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	2247#Hearing difficulty problems	http://www.ebi.ac.uk/efo/EFO_0004238	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C447#Malignant neoplasm: Skin of lower limb including hip	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J84#Other interstitial pulmonary diseases	http://www.ebi.ac.uk/efo/EFO_0004244	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D47#Other neoplasms of uncertain or unknown behaviour of lymphoid haematopoietic and related tissue	http://www.ebi.ac.uk/efo/EFO_1000201	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23453#NMR Polyunsaturated Fatty Acids to Total Fatty Acids percentage	http://www.ebi.ac.uk/efo/EFO_0022303	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z871#Personal history of diseases of the digestive system	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23599#NMR Phospholipids to Total Lipids in Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C531#Malignant neoplasm: Exocervix	http://www.ebi.ac.uk/efo/EFO_0007532	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30890#Vitamin D	http://www.ebi.ac.uk/efo/EFO_0004631	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23603#NMR Triglycerides to Total Lipids in Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022338	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	2257#Hearing difficulty problems with background noise	http://www.ebi.ac.uk/efo/EFO_0004238	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C570#Malignant neoplasm: Fallopian tube	http://purl.obolibrary.org/obo/MONDO_0002158	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5085#Spherical power (left)	http://www.ebi.ac.uk/efo/EFO_0004731	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25010#Volume of brain grey+white matter	http://www.ebi.ac.uk/efo/EFO_0008320	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25407#Mean OD in cerebral peduncle on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D563#Thalassaemia trait	http://purl.obolibrary.org/obo/HP_0005560	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter XI#Chapter XI Diseases of the digestive system	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130833#Source of report of E89 postprocedural endocrine and metabolic disorders not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000589	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30300#High light scatter reticulocyte count	http://www.ebi.ac.uk/efo/EFO_0007986	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C787#Secondary malignant neoplasm of liver and intrahepatic bile duct	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131769#Source of report of L57 skin changes due to chronic exposure to nonionising radiation	http://www.orpha.net/ORDO/Orphanet_157949	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D649#Anaemia unspecified	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1278#cataract	http://purl.obolibrary.org/obo/MONDO_0005129	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23445#NMR Omega-6 Fatty Acids	http://www.ebi.ac.uk/efo/EFO_0005680	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23585#NMR Cholesterol to Total Lipids in Very Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022244	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23569#NMR Cholesteryl Esters in Medium HDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D372#Neoplasm of uncertain or unknown behaviour: Small intestine	http://purl.obolibrary.org/obo/MONDO_0004251	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132045#Source of report of N25 disorders resulting from impaired renal tubular function	http://www.ebi.ac.uk/efo/EFO_0009566	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4101#Heel broadband ultrasound attenuation (left)	http://www.ebi.ac.uk/efo/EFO_0004514	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4104#Heel quantitative ultrasound index (QUI) direct entry (left)	http://www.ebi.ac.uk/efo/EFO_0004514	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C18#Malignant neoplasm of colon	http://www.ebi.ac.uk/efo/EFO_0004288	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q25#Congenital malformations of great arteries	http://www.orpha.net/ORDO/Orphanet_98724	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23475#NMR Acetate	http://www.ebi.ac.uk/efo/EFO_0010112	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R060#Dyspnoea	http://purl.obolibrary.org/obo/HP_0002094	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Phospholipids to Total Lipids in HDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D619#Aplastic anaemia unspecified	http://purl.obolibrary.org/obo/MONDO_0015909	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4100#Ankle spacing width (left)	http://www.ebi.ac.uk/efo/EFO_0004324	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131689#Source of report of K90 intestinal malabsorption	http://www.ebi.ac.uk/efo/EFO_0009554	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N258#Other disorders resulting from impaired renal tubular function	http://purl.obolibrary.org/obo/MONDO_0001343	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q446#Cystic disease of liver	http://www.ebi.ac.uk/efo/EFO_1001505	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C90#Multiple myeloma and malignant plasma cell neoplasms	http://www.ebi.ac.uk/efo/EFO_0001378	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q78#Other osteochondrodysplasias	http://www.ebi.ac.uk/efo/EFO_0005571	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C51-C58#C51-C58 Malignant neoplasms of female genital organs	http://www.ebi.ac.uk/efo/EFO_1001331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Z421#Follow-up care involving plastic surgery of breast	http://www.ebi.ac.uk/efo/EFO_0009642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23271#Leg lean mass (right)	http://www.ebi.ac.uk/efo/EFO_0004980	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23326#Femur neck bone area (right)	http://www.ebi.ac.uk/efo/EFO_0004511	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23412#NMR Phospholipids in VLDL	http://www.ebi.ac.uk/efo/EFO_0022154	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	48#Waist circumference	http://www.ebi.ac.uk/efo/EFO_0004342	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C67#Malignant neoplasm of bladder	http://purl.obolibrary.org/obo/MONDO_0005411	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R944#Abnormal results of kidney function studies	http://www.ebi.ac.uk/efo/EFO_0009628	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L72#Follicular cysts of skin and subcutaneous tissue	http://www.ebi.ac.uk/efo/EFO_1001329	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I710#Dissection of aorta [any part]	http://purl.obolibrary.org/obo/HP_0002647	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#R04#Haemorrhage from respiratory passages	http://purl.obolibrary.org/obo/MP_0001914	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N488#Other specified disorders of penis	http://purl.obolibrary.org/obo/MONDO_0002036	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K52#Other noninfective gastroenteritis and colitis	http://www.ebi.ac.uk/efo/EFO_1001463	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23539#NMR Phospholipids in Medium LDL	http://www.ebi.ac.uk/efo/EFO_0022183	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130807#Source of report of E74 other disorders of carbohydrate metabolism	http://www.orpha.net/ORDO/Orphanet_79161	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter VII#Chapter VII Diseases of the eye and adnexa	http://www.ebi.ac.uk/efo/EFO_0009546	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C57#Malignant neoplasm of other and unspecified female genital organs	http://www.ebi.ac.uk/efo/EFO_1001331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C54#Malignant neoplasm of corpus uteri	http://www.ebi.ac.uk/efo/EFO_0007532	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1022#colon cancer|sigmoid cancer	http://www.ebi.ac.uk/efo/EFO_1001950	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	12336#Ventricular rate	http://www.ebi.ac.uk/efo/EFO_0007928	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23637#NMR Free Cholesterol to Total Lipids in Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022279	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	6150#4#High blood pressure	http://www.ebi.ac.uk/efo/EFO_0000537	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I712#Thoracic aortic aneurysm without mention of rupture	http://www.ebi.ac.uk/efo/EFO_0004282	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D125#Benign neoplasm: Sigmoid colon	http://purl.obolibrary.org/obo/MONDO_0002278	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23586#NMR Cholesteryl Esters to Total Lipids in Very Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022258	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132565#Source of report of Q77 osteochondrodysplasia with defects of growth of tubular bones and spine	http://www.ebi.ac.uk/efo/EFO_1000695	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131287#Source of report of I10 essential primary hypertension	http://purl.obolibrary.org/obo/MONDO_0001134	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K509#Crohn disease unspecified	http://www.ebi.ac.uk/efo/EFO_0000384	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q120#Congenital cataract	http://purl.obolibrary.org/obo/HP_0000519	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K50#Crohn disease [regional enteritis]	http://www.ebi.ac.uk/efo/EFO_0000384	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3064#Peak expiratory flow (PEF)	http://www.ebi.ac.uk/efo/EFO_0009718	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Free Cholesterol to Cholesterol in Chylomicrons and Extremely Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0021898	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23581#NMR Cholesteryl Esters to Total Lipids in Chylomicrons and Extremely Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022246	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D681#Hereditary factor XI deficiency	http://purl.obolibrary.org/obo/MONDO_0020587	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23116#Leg fat mass (left)	http://www.ebi.ac.uk/efo/EFO_0005409	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25198#Mean MO in tapetum on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25552#Weighted-mean MO in tract forceps major	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K80#Cholelithiasis	http://www.ebi.ac.uk/efo/EFO_0004799	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block I26-I28#I26-I28 Pulmonary heart disease and diseases of pulmonary circulation	http://www.ebi.ac.uk/efo/EFO_0003818	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1293#bone disorder	http://www.ebi.ac.uk/efo/EFO_0004260	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E877#Fluid overload	http://purl.obolibrary.org/obo/NCIT_C199575	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block G80-G83#G80-G83 Cerebral palsy and other paralytic syndromes	http://www.ebi.ac.uk/efo/EFO_1000631	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C502#Malignant neoplasm: Upper-inner quadrant of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23472#NMR Pyruvate	http://www.ebi.ac.uk/efo/EFO_0010117	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23468#NMR Phenylalanine	http://www.ebi.ac.uk/efo/EFO_0005001	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23534#NMR Cholesteryl Esters in Large LDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23512#NMR Cholesterol in Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022228	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block G00-G09#G00-G09 Inflammatory diseases of the central nervous system	http://www.ebi.ac.uk/efo/EFO_0009386	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R066#Hiccough	http://purl.obolibrary.org/obo/NCIT_C143545	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C160#Malignant neoplasm: Cardia	http://purl.obolibrary.org/obo/MONDO_0001063	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G114#Hereditary spastic paraplegia	http://purl.obolibrary.org/obo/MONDO_0019064	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	47#Hand grip strength (right)	http://www.ebi.ac.uk/efo/EFO_0006941	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N180#N180 End-stage renal disease	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I340#Mitral (valve) insufficiency	http://www.ebi.ac.uk/efo/EFO_0009557	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1037#female genital tract cancer	http://www.ebi.ac.uk/efo/EFO_0009524	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23246#Android lean mass	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Triglycerides to Total Lipids in HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022333	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25185#Mean MO in external capsule on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D66#Hereditary factor VIII deficiency	http://www.orpha.net/ORDO/Orphanet_98878	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30190#Monocyte percentage	http://www.ebi.ac.uk/efo/EFO_0007989	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131403#Source of report of I83 varicose veins of lower extremities	http://purl.obolibrary.org/obo/HP_0002619	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131965#Source of report of M81 osteoporosis without pathological fracture	http://www.ebi.ac.uk/efo/EFO_0003882	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M13#Other arthritis	http://www.ebi.ac.uk/efo/EFO_0005856	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131649#Source of report of K63 other diseases of intestine	http://www.ebi.ac.uk/efo/EFO_0009431	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C931#Chronic myelomonocytic leukaemia	http://purl.obolibrary.org/obo/MONDO_0004600	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5257#Corneal resistance factor (right)	http://www.ebi.ac.uk/efo/EFO_0010067	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K317#Polyp of stomach and duodenum	http://purl.obolibrary.org/obo/MONDO_0002866	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23589#NMR Phospholipids to Total Lipids in Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J189#Pneumonia unspecified	http://www.ebi.ac.uk/efo/EFO_0003106	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25030#Median T2star in putamen (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C50#Malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C15-C26#C15-C26 Malignant neoplasms of digestive organs	http://purl.obolibrary.org/obo/MONDO_0002516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C180#Malignant neoplasm: Caecum	http://purl.obolibrary.org/obo/MONDO_0002033	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#E10#Type 1 diabetes mellitus	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132533#Source of report of Q61 cystic kidney disease	http://www.ebi.ac.uk/efo/EFO_0008615	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1277#glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23410#NMR Triglycerides in HDL	http://www.ebi.ac.uk/efo/EFO_0022317	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23533#NMR Cholesterol in Large LDL	http://www.ebi.ac.uk/efo/EFO_0021901	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D120#Benign neoplasm: Caecum	http://purl.obolibrary.org/obo/MONDO_0021464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N029#Recurrent and persistent haematuria; Unspecified	http://purl.obolibrary.org/obo/HP_0000790	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131349#Source of report of I47 paroxysmal tachycardia	http://www.ebi.ac.uk/efo/EFO_0009493	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z42#Follow-up care involving plastic surgery	http://www.ebi.ac.uk/efo/EFO_0009642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L57#Skin changes due to chronic exposure to nonionizing radiation	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block N17-N19#N17-N19 Renal failure	http://purl.obolibrary.org/obo/HP_0001919	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D051#Intraductal carcinoma in situ	http://www.ebi.ac.uk/efo/EFO_0000305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C56#Malignant neoplasm of ovary	http://www.ebi.ac.uk/efo/EFO_0003893	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#2#(8010-8790) Epithelial	http://www.ebi.ac.uk/efo/EFO_0000311	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesteryl Esters to Cholesterol in IDL percentage	http://www.ebi.ac.uk/efo/EFO_0022233	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C16#Malignant neoplasm of stomach	http://purl.obolibrary.org/obo/MONDO_0001056	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130715#Source of report of E14 unspecified diabetes mellitus	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5096#3mm weak meridian (left)	http://www.ebi.ac.uk/efo/EFO_0004731	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4123#Heel quantitative ultrasound index (QUI) direct entry (right)	http://www.ebi.ac.uk/efo/EFO_0004514	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E70#Disorders of aromatic amino-acid metabolism	http://purl.obolibrary.org/obo/MONDO_0037871	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z490#Preparatory care for dialysis	http://www.ebi.ac.uk/efo/EFO_0010690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23406#NMR HDL Cholesterol	http://www.ebi.ac.uk/efo/EFO_0004612	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23600#NMR Cholesterol to Total Lipids in Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022242	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D132#Benign neoplasm: Duodenum	http://www.ebi.ac.uk/efo/EFO_1000907	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23221#Arm BMD (bone mineral density) (left)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30070#Red blood cell (erythrocyte) distribution width	http://www.ebi.ac.uk/efo/EFO_0009188	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E83#Disorders of mineral metabolism	http://www.ebi.ac.uk/efo/EFO_0009556	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#E21#Hyperparathyroidism and other disorders of parathyroid gland	http://www.ebi.ac.uk/efo/EFO_0008506	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23343#Femur wards BMC (bone mineral content) (left)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C509#Malignant neoplasm: Breast unspecified	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q858#Other phakomatoses not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C911#Chronic lymphocytic leukaemia of B-cell type	http://www.ebi.ac.uk/efo/EFO_0000095	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter XXI#Chapter XXI Factors influencing health status and contact with health services	http://www.ebi.ac.uk/efo/EFO_0009786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterVII#Chapter VII Diseases of the eye and adnexa	http://www.ebi.ac.uk/efo/EFO_0009546	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1328#haemophilia	http://www.orpha.net/ORDO/Orphanet_448	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131367#Source of report of I63 cerebral infarction	http://purl.obolibrary.org/obo/MONDO_0002679	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N209#Urinary calculus unspecified	http://purl.obolibrary.org/obo/NCIT_C26905	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	42027#Source of end stage renal disease report	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30790#Lipoprotein A	http://www.ebi.ac.uk/efo/EFO_0006925	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23121#Arm fat-free mass (right)	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132453#Source of report of Q12 congenital lens malformations	http://purl.obolibrary.org/obo/HP_0000517	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130667#Source of report of D73 diseases of spleen	http://www.ebi.ac.uk/efo/EFO_0000540	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block H90-H95#H90-H95 Other disorders of ear	http://www.ebi.ac.uk/efo/EFO_0009668	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1039#ovarian cancer	http://www.ebi.ac.uk/efo/EFO_0001075	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40012#1#Uncertain whether benign or malignant	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#9823#Chronic lymphocytic leukemia|small lymphocytic lymphoma	http://www.ebi.ac.uk/efo/EFO_0000095	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I219#Acute myocardial infarction unspecified	http://www.ebi.ac.uk/efo/EFO_0000612	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D462#Refractory anaemia with excess of blasts [RAEB]	http://www.ebi.ac.uk/efo/EFO_0003811	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131603#Source of report of K31 other diseases of stomach and duodenum	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C508#Malignant neoplasm: Overlapping lesion of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K91#Postprocedural disorders of digestive system not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#G44#Other headache syndromes	http://www.ebi.ac.uk/efo/EFO_0009550	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D47#Other neoplasms of uncertain or unknown behaviour of lymphoid haematopoietic and related tissue	http://www.ebi.ac.uk/efo/EFO_0001642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block D37-D48#D37-D48 Neoplasms of uncertain or unknown behaviour	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block Q60-Q64#Q60-Q64 Congenital malformations of the urinary system	http://purl.obolibrary.org/obo/HP_0000079	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8070#Squamous cell carcinoma	http://www.ebi.ac.uk/efo/EFO_0000707	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23576#NMR Cholesteryl Esters in Small HDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23597#NMR Free Cholesterol to Total Lipids in Medium VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022284	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131185#Source of report of H36 retinal disorders in DCE	http://www.ebi.ac.uk/efo/EFO_0003839	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1226#hypothyroidism|myxoedema	http://www.ebi.ac.uk/efo/EFO_1001055	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z857#Personal history of other malignant neoplasms of lymphoid haematopoietic and related tissues	http://purl.obolibrary.org/obo/NCIT_C18849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23621#NMR Cholesteryl Esters to Total Lipids in Medium LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022252	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C501#Malignant neoplasm: Central portion of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132567#Source of report of Q78 other osteochondrodysplasias	http://www.ebi.ac.uk/efo/EFO_1000695	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E785#Hyperlipidaemia unspecified	http://purl.obolibrary.org/obo/HP_0003077	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25026#Median T2star in thalamus (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20151#Forced vital capacity (FVC) Best measure	http://www.ebi.ac.uk/efo/EFO_0004312	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I501#Left ventricular failure	http://www.ebi.ac.uk/efo/EFO_0004295	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K31#Other diseases of stomach and duodenum	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Z42#Follow-up care involving plastic surgery	http://www.ebi.ac.uk/efo/EFO_0009642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block G50-G59#G50-G59 Nerve| nerve root and plexus disorders	http://www.ebi.ac.uk/efo/EFO_0009387	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1453#psoriasis	http://www.ebi.ac.uk/efo/EFO_0000676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#M16#Coxarthrosis [arthrosis of hip]	http://www.ebi.ac.uk/efo/EFO_1000786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23423#NMR Total Lipids in Lipoprotein Particles	http://www.ebi.ac.uk/efo/EFO_0022309	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23601#NMR Cholesteryl Esters to Total Lipids in Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022256	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z08#Follow-up examination after treatment for malignant neoplasms	http://www.ebi.ac.uk/efo/EFO_0009642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K900#Coeliac disease	http://www.ebi.ac.uk/efo/EFO_0001060	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M109#Gout unspecified	http://www.ebi.ac.uk/efo/EFO_0004274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130685#Source of report of D84 other immunodeficiencies	http://www.ebi.ac.uk/efo/EFO_0000540	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I422#Other hypertrophic cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000538	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter IX#Chapter IX Diseases of the circulatory system	http://www.ebi.ac.uk/efo/EFO_0000319	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E74#Other disorders of carbohydrate metabolism	http://www.orpha.net/ORDO/Orphanet_79161	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z510#Radiotherapy session	http://purl.obolibrary.org/obo/OAE_0000235	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K222#Oesophageal obstruction	http://purl.obolibrary.org/obo/NCIT_C78279	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R458#Other symptoms and signs involving emotional state	http://www.ebi.ac.uk/efo/EFO_0007803	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I67#Other cerebrovascular diseases	http://www.ebi.ac.uk/efo/EFO_0003763	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23483#NMR Phospholipids in Chylomicrons and Extremely Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022292	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131339#Source of report of I42 cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I26#Pulmonary embolism	http://www.ebi.ac.uk/efo/EFO_0003827	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H55#Nystagmus and other irregular eye movements	http://purl.obolibrary.org/obo/HP_0000639	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C78#Secondary malignant neoplasm of respiratory and digestive organs	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R06#Abnormalities of breathing	http://purl.obolibrary.org/obo/HP_0005957	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M15#Polyarthrosis	http://www.ebi.ac.uk/efo/EFO_1000999	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R098#Other specified symptoms and signs involving the circulatory and respiratory systems	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R098#Other specified symptoms and signs involving the circulatory and respiratory systems	http://www.ebi.ac.uk/efo/EFO_0000319	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23228#Leg BMC (bone mineral content) (right)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G600#Hereditary motor and sensory neuropathy	http://www.orpha.net/ORDO/Orphanet_140450	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#R31#Unspecified haematuria	http://purl.obolibrary.org/obo/HP_0000790	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#D46#Myelodysplastic syndromes	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	2966#Age high blood pressure diagnosed	http://www.ebi.ac.uk/efo/EFO_0004772	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23563#NMR Free Cholesterol in Large HDL	http://www.ebi.ac.uk/efo/EFO_0022157	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C541#Malignant neoplasm: Endometrium	http://purl.obolibrary.org/obo/MONDO_0011962	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131647#Source of report of K62 other diseases of anus and rectum	http://www.ebi.ac.uk/efo/EFO_0009685	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25362#Mean ICVF in posterior limb of internal capsule on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#J84#Other interstitial pulmonary diseases	http://www.ebi.ac.uk/efo/EFO_0004244	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1074#angina	http://www.ebi.ac.uk/efo/EFO_0003913	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23437#NMR Phosphatidylcholines	http://www.ebi.ac.uk/efo/EFO_0004639	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C833#Diffuse large B-cell lymphoma	http://www.ebi.ac.uk/efo/EFO_0000403	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23638#NMR Triglycerides to Total Lipids in Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022330	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D128#Benign neoplasm: Rectum	http://purl.obolibrary.org/obo/MONDO_0002165	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23594#NMR Phospholipids to Total Lipids in Medium VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30050#Mean corpuscular haemoglobin	http://www.ebi.ac.uk/efo/EFO_0004527	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block R25-R29#R25-R29 Symptoms and signs involving the nervous and musculoskeletal systems	http://purl.obolibrary.org/obo/HP_0000924	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23508#NMR Triglycerides in Medium VLDL	http://www.ebi.ac.uk/efo/EFO_0022154	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3147#Heel quantitative ultrasound index (QUI) direct entry	http://www.ebi.ac.uk/efo/EFO_0004514	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G06#Intracranial and intraspinal abscess and granuloma	http://www.ebi.ac.uk/efo/EFO_0003030	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C91#Lymphoid leukaemia	http://www.ebi.ac.uk/efo/EFO_0004289	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25007#Volume of white matter (normalised for head size)	http://www.ebi.ac.uk/efo/EFO_0008320	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Triglycerides to Total Lipids in LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23432#NMR Average Diameter for LDL Particles	http://www.ebi.ac.uk/efo/EFO_0008593	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30610#Alkaline phosphatase	http://www.ebi.ac.uk/efo/EFO_0004533	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C447#Malignant neoplasm: Skin of lower limb including hip	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23130#Trunk predicted mass	http://www.ebi.ac.uk/efo/EFO_0004324	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K802#Calculus of gallbladder without cholecystitis	http://www.ebi.ac.uk/efo/EFO_0004799	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131297#Source of report of I20 angina pectoris	http://www.ebi.ac.uk/efo/EFO_0003913	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25033#Median T2star in pallidum (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C91#Lymphoid leukaemia	http://www.ebi.ac.uk/efo/EFO_0004289	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C437#Malignant neoplasm: Malignant melanoma of lower limb including hip	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1229#parathyroid gland problem (not cancer)	http://www.ebi.ac.uk/efo/EFO_0005754	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#ChapterI#Chapter I Certain infectious and parasitic diseases	http://www.ebi.ac.uk/efo/EFO_0001067	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30180#Lymphocyte percentage	http://www.ebi.ac.uk/efo/EFO_0007993	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I20#Angina pectoris	http://www.ebi.ac.uk/efo/EFO_0003913	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1161#gall bladder disease	http://www.ebi.ac.uk/efo/EFO_0003832	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C45#Mesothelioma	http://purl.obolibrary.org/obo/MONDO_0005065	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E875#Hyperkalaemia	http://purl.obolibrary.org/obo/HP_0002153	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#M12#Other specific arthropathies	http://www.ebi.ac.uk/efo/EFO_1000999	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#A41#Other sepsis	http://purl.obolibrary.org/obo/HP_0100806	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23521#NMR Free Cholesterol in Very Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022275	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R509#Fever unspecified	http://purl.obolibrary.org/obo/HP_0001945	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25095#Mean FA in fornix cres+stria terminalis on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130699#Source of report of E04 other non toxic goitre	http://www.ebi.ac.uk/efo/EFO_0004283	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q12#Congenital lens malformations	http://purl.obolibrary.org/obo/HP_0000517	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C61#Malignant neoplasm of prostate	http://www.ebi.ac.uk/efo/EFO_0001663	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#ChapterII#Chapter II Neoplasms	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z131#Special screening examination for diabetes mellitus	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23640#NMR Cholesterol to Total Lipids in Medium HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022237	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I252#Old myocardial infarction	http://www.ebi.ac.uk/efo/EFO_0000612	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block J80-J84#J80-J84 Other respiratory diseases principally affecting the interstitium	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N394#Other specified urinary incontinence	http://purl.obolibrary.org/obo/HP_0000020	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C85#Other and unspecified types of non-Hodgkin lymphoma	http://www.ebi.ac.uk/efo/EFO_0005952	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23341#Femur wards bone area (left)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C34#Malignant neoplasm of bronchus and lung	http://purl.obolibrary.org/obo/MONDO_0008903	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130847#Source of report of F05 delirium not induced by alcohol and other psychoactive substances	http://www.ebi.ac.uk/efo/EFO_0009267	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C504#Malignant neoplasm: Upper-outer quadrant of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23124#Arm fat mass (left)	http://www.ebi.ac.uk/efo/EFO_0005409	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3148#Heel bone mineral density (BMD)	http://www.ebi.ac.uk/efo/EFO_0009270	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131285#Source of report of I09 other rheumatic heart diseases	http://www.ebi.ac.uk/efo/EFO_1001161	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25246#Mean L1 in tapetum on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20009#Interpolated Age of participant when non-cancer illness first diagnosed	http://www.ebi.ac.uk/efo/EFO_0000408	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D45#Polycythaemia vera	http://www.ebi.ac.uk/efo/EFO_0002429	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q27#Other congenital malformations of peripheral vascular system	http://purl.obolibrary.org/obo/HP_0002597	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1223#type 2 diabetes	http://purl.obolibrary.org/obo/MONDO_0005148	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E876#Hypokalaemia	http://purl.obolibrary.org/obo/HP_0002900	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131691#Source of report of K91 postprocedural disorders of digestive system not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J45#Asthma	http://purl.obolibrary.org/obo/MONDO_0004979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C54#Malignant neoplasm of corpus uteri	http://www.ebi.ac.uk/efo/EFO_0007532	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23306#Head BMC (bone mineral content)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D569#Thalassaemia unspecified	http://www.ebi.ac.uk/efo/EFO_1001996	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3063#Forced expiratory volume in 1-second (FEV1)	http://www.ebi.ac.uk/efo/EFO_0005921	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D58#Other hereditary haemolytic anaemias	http://purl.obolibrary.org/obo/HP_0004804	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block I26-I28#I26-I28 Pulmonary heart disease and diseases of pulmonary circulation	http://www.ebi.ac.uk/efo/EFO_0003818	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23415#NMR Total Esterified Cholesterol	http://www.ebi.ac.uk/efo/EFO_0008589	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23440#NMR Apolipoprotein A1	http://www.ebi.ac.uk/efo/EFO_0004614	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23592#NMR Free Cholesterol to Total Lipids in Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022281	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23540#NMR Cholesterol in Medium LDL	http://www.ebi.ac.uk/efo/EFO_0022185	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23513#NMR Cholesteryl Esters in Small VLDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130643#Source of report of D61 other aplastic anaemias	http://purl.obolibrary.org/obo/MONDO_0015909	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131345#Source of report of I45 other conduction disorders	http://www.ebi.ac.uk/efo/EFO_0005137	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D72#Other disorders of white blood cells	http://purl.obolibrary.org/obo/HP_0001881	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132477#Source of report of Q25 congenital malformations of great arteries	http://www.orpha.net/ORDO/Orphanet_98724	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C61#Malignant neoplasm of prostate	http://purl.obolibrary.org/obo/MONDO_0021259	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block L60-L75#L60-L75 Disorders of skin appendages	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K869#Disease of pancreas unspecified	http://www.ebi.ac.uk/efo/EFO_0009605	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30730#Gamma glutamyltransferase	http://www.ebi.ac.uk/efo/EFO_0004532	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D471#Chronic myeloproliferative disease	http://www.ebi.ac.uk/efo/EFO_0002428	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I42#Cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D73#Diseases of spleen	http://www.ebi.ac.uk/efo/EFO_0009002	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block Z40-Z54#Z40-Z54 Persons encountering health services for specific procedures and health care	http://www.ebi.ac.uk/efo/EFO_0009786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1003#skin cancer	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22331#QT interval	http://www.ebi.ac.uk/efo/EFO_0004682	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Phospholipids to Total Lipids in VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23223#Arm BMD (bone mineral density) (right)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23613#NMR Triglycerides to Total Lipids in IDL percentage	http://www.ebi.ac.uk/efo/EFO_0022329	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23111#Leg fat percentage (right)	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20154#Forced expiratory volume in 1-second (FEV1) predicted percentage	http://www.ebi.ac.uk/efo/EFO_0004314	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132033#Source of report of N18 chronic renal failure	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131791#Source of report of L70 acne	http://www.ebi.ac.uk/efo/EFO_0003894	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C18#Malignant neoplasm of colon	http://www.ebi.ac.uk/efo/EFO_1001950	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C50#Malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C81-C96#C81-C96 Malignant neoplasms| stated or presumed to be primary| of lymphoid| haematopoietic and related tissue	http://purl.obolibrary.org/obo/MONDO_0002334	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23559#NMR Total Lipids in Large HDL	http://www.ebi.ac.uk/efo/EFO_0022189	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25383#Mean ICVF in fornix cres+stria terminalis on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C809#Malignant neoplasm primary site unspecified	http://www.ebi.ac.uk/efo/EFO_0000311	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131295#Source of report of I15 secondary hypertension	http://www.ebi.ac.uk/efo/EFO_1002034	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25215#Mean L1 in cerebral peduncle on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q874#Marfan syndrome	http://purl.obolibrary.org/obo/MONDO_0007947	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25361#Mean ICVF in anterior limb of internal capsule on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I489#Atrial fibrillation and atrial flutter unspecified	http://www.ebi.ac.uk/efo/EFO_0000275	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23108#Impedance of leg (left)	http://purl.obolibrary.org/obo/HP_0000924	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4233#Mean signal-to-noise ratio (SNR) (left)	http://purl.obolibrary.org/obo/MS_1001884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Total Free Cholesterol to Total Lipids percentage	http://www.ebi.ac.uk/efo/EFO_0020945	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23635#NMR Cholesterol to Total Lipids in Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022234	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23608#NMR Triglycerides to Total Lipids in Very Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022341	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30120#Lymphocyte count	http://www.ebi.ac.uk/efo/EFO_0004587	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C96#Other and unspecified malignant neoplasms of lymphoid haematopoietic and related tissue	http://purl.obolibrary.org/obo/MONDO_0002334	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25253#Mean L2 in fornix on FA skeleton	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J449#Chronic obstructive pulmonary disease unspecified	http://www.ebi.ac.uk/efo/EFO_0000341	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E780#Pure hypercholesterolaemia	http://purl.obolibrary.org/obo/HP_0003124	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D25#Leiomyoma of uterus	http://purl.obolibrary.org/obo/HP_0000131	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block J09-J18#J09-J18 Influenza and pneumonia	http://www.ebi.ac.uk/efo/EFO_0007328	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23337#Femur troch bone area (left)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	46#Hand grip strength (left)	http://www.ebi.ac.uk/efo/EFO_0006941	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25061#Mean FA in fornix on FA skeleton	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25003#Volume of ventricular cerebrospinal fluid (normalised for head size)	http://www.ebi.ac.uk/efo/EFO_0008080	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K519#Ulcerative colitis unspecified	http://www.ebi.ac.uk/efo/EFO_0000729	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D059#Carcinoma in situ of breast unspecified	http://www.ebi.ac.uk/efo/EFO_0000305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C504#Malignant neoplasm: Upper-outer quadrant of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D462#Refractory anaemia with excess of blasts [RAEB]	http://www.ebi.ac.uk/efo/EFO_0003811	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I420#Dilated cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I501#Left ventricular failure	http://www.ebi.ac.uk/efo/EFO_0004295	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D473#Essential (haemorrhagic) thrombocythaemia	http://www.ebi.ac.uk/efo/EFO_0000479	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C56#Malignant neoplasm of ovary	http://www.ebi.ac.uk/efo/EFO_0003893	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#Block C43-C44#C43-C44 Melanoma and other malignant neoplasms of skin	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z848#Family history of other specified conditions	http://www.ebi.ac.uk/efo/EFO_0000508	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131865#Source of report of M13 other arthritis	http://www.ebi.ac.uk/efo/EFO_0005856	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesteryl Esters to Total Lipids in LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022249	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30020#Haemoglobin concentration	http://www.ebi.ac.uk/efo/EFO_0004509	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K59#Other functional intestinal disorders	http://www.ebi.ac.uk/efo/EFO_0009431	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23260#Arms total mass	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J90#Pleural effusion not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0009637	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I518#Other ill-defined heart diseases	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D84#Other immunodeficiencies	http://www.ebi.ac.uk/efo/EFO_0000540	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8743#Superficial spreading melanoma	http://www.ebi.ac.uk/efo/EFO_0000756	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22192#Z-adjusted T/S log	http://www.ebi.ac.uk/efo/EFO_0004505	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Triglycerides to Total Lipids in VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022335	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G64#Other disorders of peripheral nervous system	http://www.ebi.ac.uk/efo/EFO_0009387	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131351#Source of report of I48 atrial fibrillation and flutter	http://www.ebi.ac.uk/efo/EFO_0000275	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E07#Other disorders of thyroid	http://www.ebi.ac.uk/efo/EFO_1000627	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D70#Agranulocytosis	http://purl.obolibrary.org/obo/HP_0012234	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesterol to Total Lipids in VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022236	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23625#NMR Cholesterol to Total Lipids in Small LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022241	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C16#Malignant neoplasm of stomach	http://purl.obolibrary.org/obo/MONDO_0001056	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25006#Volume of grey matter	http://www.ebi.ac.uk/efo/EFO_0005420	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23220#Arm BMC (bone mineral content) (left)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25094#Mean FA in fornix cres+stria terminalis on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0005674	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block R90-R94#R90-R94 Abnormal findings on diagnostic imaging and in function studies| without diagnosis	http://www.ebi.ac.uk/efo/EFO_0000720	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C92#Myeloid leukaemia	http://purl.obolibrary.org/obo/MONDO_0004643	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23201#L1-L4 average height	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C45-C49#C45-C49 Malignant neoplasms of mesothelial and soft tissue	http://www.ebi.ac.uk/efo/EFO_1000355	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C182#Malignant neoplasm: Ascending colon	http://www.ebi.ac.uk/efo/EFO_1001950	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q619#Cystic kidney disease unspecified	http://www.ebi.ac.uk/efo/EFO_0008615	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z85#Personal history of malignant neoplasm	http://www.ebi.ac.uk/efo/EFO_0000311	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131357#Source of report of I51 complications and ill defined descriptions of heart disease	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z12#Special screening examination for neoplasms	http://www.ebi.ac.uk/efo/EFO_0021523	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130671#Source of report of D75 other diseases of blood and blood forming organs	http://www.ebi.ac.uk/efo/EFO_0005803	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I839#Varicose veins of lower extremities without ulcer or inflammation	http://purl.obolibrary.org/obo/HP_0002619	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23441#NMR Apolipoprotein B to Apolipoprotein A1 ratio	http://www.ebi.ac.uk/efo/EFO_0021897	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23611#NMR Cholesteryl Esters to Total Lipids in IDL percentage	http://www.ebi.ac.uk/efo/EFO_0022247	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30770#IGF-1	http://www.ebi.ac.uk/efo/EFO_0004627	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E804#Gilbert syndrome	http://www.ebi.ac.uk/efo/EFO_0005556	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23117#Leg fat-free mass (left)	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z421#Follow-up care involving plastic surgery of breast	http://www.ebi.ac.uk/efo/EFO_0009642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H40#Glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q828#Other specified congenital malformations of skin	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Q38-Q45#Q38-Q45 Other congenital malformations of the digestive system	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block I70-I79#I70-I79 Diseases of arteries| arterioles and capillaries	http://purl.obolibrary.org/obo/MONDO_0000473	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C44#Other malignant neoplasms of skin	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23554#NMR Cholesterol in Very Large HDL	http://www.ebi.ac.uk/efo/EFO_0022229	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30620#Alanine aminotransferase	http://www.ebi.ac.uk/efo/EFO_0004735	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25730#Weighted-mean ISOVF in tract uncinate fasciculus (right)	http://www.ebi.ac.uk/efo/EFO_0006930	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q850#Neurofibromatosis (nonmalignant)	http://www.ebi.ac.uk/efo/EFO_0008514	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C15-C26#C15-C26 Malignant neoplasms of digestive organs	http://purl.obolibrary.org/obo/MONDO_0002516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23454#NMR Monounsaturated Fatty Acids to Total Fatty Acids percentage	http://www.ebi.ac.uk/efo/EFO_0022305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30740#Glucose	http://www.ebi.ac.uk/efo/EFO_0004468	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23488#NMR Concentration of Very Large VLDL Particles	http://www.ebi.ac.uk/efo/EFO_0022173	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K909#Intestinal malabsorption unspecified	http://www.ebi.ac.uk/efo/EFO_0009554	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23518#NMR Phospholipids in Very Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022150	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23120#Arm fat mass (right)	http://www.ebi.ac.uk/efo/EFO_0005409	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130819#Source of report of E80 disorders of porphyrin and bilirubin metabolism	http://purl.obolibrary.org/obo/MONDO_0037821	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E21#Hyperparathyroidism and other disorders of parathyroid gland	http://www.ebi.ac.uk/efo/EFO_0008506	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23421#NMR Free Cholesterol in LDL	http://www.ebi.ac.uk/efo/EFO_0022266	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z854#Personal history of malignant neoplasm of genital organs	http://www.ebi.ac.uk/efo/EFO_1000051	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23532#NMR Phospholipids in Large LDL	http://www.ebi.ac.uk/efo/EFO_0022174	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q878#Other specified congenital malformation syndromes not elsewhere classified	http://purl.obolibrary.org/obo/MONDO_0021147	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D696#Thrombocytopenia unspecified	http://purl.obolibrary.org/obo/HP_0001873	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E80#Disorders of porphyrin and bilirubin metabolism	http://purl.obolibrary.org/obo/MONDO_0024431	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R31#Unspecified haematuria	http://purl.obolibrary.org/obo/HP_0000790	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#ChapterXVII#Chapter XVII Congenital malformations| deformations and chromosomal abnormalities	http://purl.obolibrary.org/obo/MONDO_0021147	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block E20-E35#E20-E35 Disorders of other endocrine glands	http://www.ebi.ac.uk/efo/EFO_0001379	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23128#Trunk fat mass	http://www.ebi.ac.uk/efo/EFO_0005409	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H919#Hearing loss unspecified	http://www.ebi.ac.uk/efo/EFO_0004238	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D728#Other specified disorders of white blood cells	http://purl.obolibrary.org/obo/HP_0001881	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#C80#Malignant neoplasm without specification of site	http://www.ebi.ac.uk/efo/EFO_0000311	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130227#Source of report of B35 dermatophytosis	http://purl.obolibrary.org/obo/MONDO_0004678	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K660#Peritoneal adhesions	http://purl.obolibrary.org/obo/OAE_0004620	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23550#NMR Triglycerides in Small LDL	http://www.ebi.ac.uk/efo/EFO_0022323	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C920#Acute myeloblastic leukaemia [AML]	http://www.ebi.ac.uk/efo/EFO_0000222	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I472#Ventricular tachycardia	http://www.ebi.ac.uk/efo/EFO_0005306	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25409#Mean OD in anterior limb of internal capsule on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block R30-R39#R30-R39 Symptoms and signs involving the urinary system	http://purl.obolibrary.org/obo/HP_0000079	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23557#NMR Triglycerides in Very Large HDL	http://www.ebi.ac.uk/efo/EFO_0022324	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D234#Benign neoplasm: Skin of scalp and neck	http://purl.obolibrary.org/obo/MONDO_0021440	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23537#NMR Concentration of Medium LDL Particles	http://www.ebi.ac.uk/efo/EFO_0022172	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23496#NMR Total Lipids in Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022175	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	6150#2#Angina	http://www.ebi.ac.uk/efo/EFO_0003913	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5099#3mm weak meridian (right)	http://www.ebi.ac.uk/efo/EFO_0004731	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#J181#Lobar pneumonia unspecified	http://www.ebi.ac.uk/efo/EFO_0003106	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I50#Heart failure	http://www.ebi.ac.uk/efo/EFO_0003144	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C50-C50#C50-C50 Malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#J931#Other spontaneous pneumothorax	http://purl.obolibrary.org/obo/MONDO_0002076	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D63#Anaemia in chronic diseases classified elsewhere	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block I10-I15#I10-I15 Hypertensive diseases	http://www.ebi.ac.uk/efo/EFO_0000537	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130019#Source of report of A09 diarrhoea and gastro enteritis of presumed infectious origin	http://www.ebi.ac.uk/efo/EFO_1001463	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Free Cholesterol to Total Lipids in VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022236	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23511#NMR Phospholipids in Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022146	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N185#Chronic kidney disease stage 5	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D44#Neoplasm of uncertain or unknown behaviour of endocrine glands	http://www.ebi.ac.uk/efo/EFO_0003769	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C44#Other malignant neoplasms of skin	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	49#Hip circumference	http://www.ebi.ac.uk/efo/EFO_0005093	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23466#NMR Leucine	http://www.ebi.ac.uk/efo/EFO_0004747	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23333#Femur total area (left)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J96#Respiratory failure not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0009686	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z853#Personal history of malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C189#Malignant neoplasm: Colon unspecified	http://www.ebi.ac.uk/efo/EFO_1001950	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30280#Immature reticulocyte fraction	http://www.ebi.ac.uk/efo/EFO_0009253	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I429#Cardiomyopathy unspecified	http://www.ebi.ac.uk/efo/EFO_0000318	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D685#Primary Thrombophilia	http://www.ebi.ac.uk/efo/EFO_0009315	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D638#Anaemia in other chronic diseases classified elsewhere	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I78#Diseases of capillaries	http://www.ebi.ac.uk/efo/EFO_0004264	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#Block D37-D48#D37-D48 Neoplasms of uncertain or unknown behaviour	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1020#large bowel cancer|colorectal cancer	http://www.ebi.ac.uk/efo/EFO_1001951	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1451#hereditary|genetic haematological disorder	http://www.ebi.ac.uk/efo/EFO_0005803	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterIII#Chapter III Diseases of the blood and blood-forming organs and certain disorders involving the immune mechanism	http://www.ebi.ac.uk/efo/EFO_0000540	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z82#Family history of certain disabilities and chronic diseases leading to disablement	http://snomed.info/id/SNOMED_281666001	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23555#NMR Cholesteryl Esters in Very Large HDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	42017#Source of chronic obstructive pulmonary disease report	http://www.ebi.ac.uk/efo/EFO_0000341	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D361#Benign neoplasm: Peripheral nerves and autonomic nervous system	http://purl.obolibrary.org/obo/MONDO_0002366	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30270#Mean sphered cell volume	http://www.ebi.ac.uk/efo/EFO_0004526	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25027#Median T2star in thalamus (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N179#Acute renal failure unspecified	http://purl.obolibrary.org/obo/HP_0001919	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E211#Secondary hyperparathyroidism not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_1001173	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22191#Adjusted T/S ratio	http://www.ebi.ac.uk/efo/EFO_0004505	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23426#NMR Total Lipids in HDL	http://www.ebi.ac.uk/efo/EFO_0022307	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23617#NMR Free Cholesterol to Total Lipids in Large LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D122#Benign neoplasm: Ascending colon	http://purl.obolibrary.org/obo/MONDO_0002278	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D619#Aplastic anaemia unspecified	http://www.ebi.ac.uk/efo/EFO_0006926	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C443#Malignant neoplasm: Skin of other and unspecified parts of face	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C931#Chronic myelomonocytic leukaemia	http://www.ebi.ac.uk/efo/EFO_1001779	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E210#Primary hyperparathyroidism	http://www.ebi.ac.uk/efo/EFO_0008519	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J841#Other interstitial pulmonary diseases with fibrosis	http://www.ebi.ac.uk/efo/EFO_0009448	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25538#Weighted-mean MD in tract superior thalamic radiation (left)	http://www.ebi.ac.uk/efo/EFO_0006930	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8090#Basal cell carcinoma NOS	http://www.ebi.ac.uk/efo/EFO_0004193	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#M23#Internal derangement of knee	http://www.ebi.ac.uk/efo/EFO_0009507	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K628#Other specified diseases of anus and rectum	http://www.ebi.ac.uk/efo/EFO_0009685	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Q10-Q18#Q10-Q18 Congenital malformations of eye| ear| face and neck	http://www.ebi.ac.uk/efo/EFO_0000508	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L60#Nail disorders	http://purl.obolibrary.org/obo/MONDO_0002884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block L55-L59#L55-L59 Radiation-related disorders of the skin and subcutaneous tissue	http://www.ebi.ac.uk/efo/EFO_0009565	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8461#Serous surface papillary carcinoma	http://www.ebi.ac.uk/efo/EFO_1000646	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q612#Polycystic kidney autosomal dominant	http://www.ebi.ac.uk/efo/EFO_0008620	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D377#Neoplasm of uncertain or unknown behaviour: Other digestive organs	http://www.ebi.ac.uk/efo/EFO_0008549	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C55#Malignant neoplasm of uterus part unspecified	http://www.ebi.ac.uk/efo/EFO_0007532	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22147#Age asthma diagnosed by doctor	http://purl.obolibrary.org/obo/MONDO_0004979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30290#High light scatter reticulocyte percentage	http://www.ebi.ac.uk/efo/EFO_0010700	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I251#Atherosclerotic heart disease	http://www.ebi.ac.uk/efo/EFO_0009783	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25646#Weighted-mean L3 in tract superior thalamic radiation (left)	http://www.ebi.ac.uk/efo/EFO_0006930	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Q80-Q89#Q80-Q89 Other congenital malformations	http://www.ebi.ac.uk/efo/EFO_0009682	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#G060#Intracranial abscess and granuloma	http://www.ebi.ac.uk/efo/EFO_0003030	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132511#Source of report of Q43 other congenital malformations of intestine	http://purl.obolibrary.org/obo/MONDO_0021147	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C259#Malignant neoplasm: Pancreas unspecified	http://www.ebi.ac.uk/efo/EFO_0002618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23106#Impedance of whole body	http://purl.obolibrary.org/obo/HP_0000924	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D61#Other aplastic anaemias	http://purl.obolibrary.org/obo/HP_0001915	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C56#Malignant neoplasm of ovary	http://www.ebi.ac.uk/efo/EFO_0003893	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23407#NMR Total Triglycerides	http://www.ebi.ac.uk/efo/EFO_0004530	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131837#Source of report of L98 other disorders of skin and subcutaneous tissue not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C578#Malignant neoplasm: Overlapping lesion of female genital organs	http://www.ebi.ac.uk/efo/EFO_1001331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30130#Monocyte count	http://www.ebi.ac.uk/efo/EFO_0005091	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C482#Malignant neoplasm: Peritoneum unspecified	http://purl.obolibrary.org/obo/MONDO_0002087	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30240#Reticulocyte percentage	http://www.ebi.ac.uk/efo/EFO_0010700	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#M4782#Other spondylosis Cervical region	http://purl.obolibrary.org/obo/MONDO_0002253	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4103#Speed of sound through heel (left)	http://www.ebi.ac.uk/efo/EFO_0005654	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I710#Dissection of aorta [any part]	http://purl.obolibrary.org/obo/HP_0002647	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter I#Chapter I Certain infectious and parasitic diseases	http://www.ebi.ac.uk/efo/EFO_0001067	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block K65-K67#K65-K67 Diseases of peritoneum	http://www.ebi.ac.uk/efo/EFO_0008588	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23438#NMR Sphingomyelins	http://www.ebi.ac.uk/efo/EFO_0010118	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23631#NMR Cholesteryl Esters to Total Lipids in Very Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022257	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23591#NMR Cholesteryl Esters to Total Lipids in Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022250	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z837#Family history of diseases of the digestive system	http://www.ebi.ac.uk/efo/EFO_0009605	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23123#Arm fat percentage (left)	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z400#Prophylactic surgery for risk-factors related to malignant neoplasms	http://www.ebi.ac.uk/efo/EFO_0009580	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4105#Heel bone mineral density (BMD) (left)	http://www.ebi.ac.uk/efo/EFO_0009270	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132585#Source of report of Q87 other specified congenital malformation syndromes affecting multiple systems	http://www.ebi.ac.uk/efo/EFO_0009676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q87#Other specified congenital malformation syndromes affecting multiple systems	http://www.ebi.ac.uk/efo/EFO_0009676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block Q80-Q89#Q80-Q89 Other congenital malformations	http://www.ebi.ac.uk/efo/EFO_0009682	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G560#Carpal tunnel syndrome	http://www.ebi.ac.uk/efo/EFO_0004143	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23514#NMR Free Cholesterol in Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022272	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23510#NMR Total Lipids in Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022148	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D680#Von Willebrand disease	http://www.orpha.net/ORDO/Orphanet_52530	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130657#Source of report of D68 other coagulation defects	http://www.ebi.ac.uk/efo/EFO_0005803	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131813#Source of report of L85 other epidermal thickening	http://purl.obolibrary.org/obo/HP_0011368	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4125#Heel bone mineral density (BMD) T-score automated (right)	http://www.ebi.ac.uk/efo/EFO_0009270	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L570#Actinic keratosis	http://www.ebi.ac.uk/efo/EFO_0002496	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D259#Leiomyoma of uterus unspecified	http://purl.obolibrary.org/obo/HP_0000131	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C79#Secondary malignant neoplasm of other and unspecified sites	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I421#Obstructive hypertrophic cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000538	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D75#Other diseases of blood and blood-forming organs	http://www.ebi.ac.uk/efo/EFO_0005803	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1162#cholelithiasis|gall stones	http://www.ebi.ac.uk/efo/EFO_0004799	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N329#Bladder disorder unspecified	http://www.ebi.ac.uk/efo/EFO_1000018	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30810#Phosphate	http://www.ebi.ac.uk/efo/EFO_0010968	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23587#NMR Free Cholesterol to Total Lipids in Very Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022289	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C83#Non-follicular lymphoma	http://www.ebi.ac.uk/efo/EFO_0005952	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23612#NMR Free Cholesterol to Total Lipids in IDL percentage	http://www.ebi.ac.uk/efo/EFO_0022278	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C920#Acute myeloblastic leukaemia [AML]	http://www.ebi.ac.uk/efo/EFO_0000222	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131179#Source of report of H33 retinal detachments and breaks	http://www.ebi.ac.uk/efo/EFO_0005773	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25406#Mean OD in cerebral peduncle on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4106#Heel bone mineral density (BMD) T-score automated (left)	http://www.ebi.ac.uk/efo/EFO_0009270	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I48#Atrial fibrillation and flutter	http://www.ebi.ac.uk/efo/EFO_0000275	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block G10-G14#G10-G14 Systemic atrophies primarily affecting the central nervous system	http://purl.obolibrary.org/obo/HP_0007367	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131325#Source of report of I35 nonrheumatic aortic valve disorders	http://www.ebi.ac.uk/efo/EFO_0009531	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23312#Spine BMC (bone mineral content)	http://www.ebi.ac.uk/efo/EFO_0007701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	2976#Age diabetes diagnosed	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C447#Malignant neoplasm: Skin of lower limb including hip	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130815#Source of report of E78 disorders of lipoprotein metabolism and other lipidaemias	http://www.ebi.ac.uk/efo/EFO_0000589	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#D469#Myelodysplastic syndrome unspecified	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D50#Iron deficiency anaemia	http://purl.obolibrary.org/obo/HP_0001891	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K29#Gastritis and duodenitis	http://www.ebi.ac.uk/efo/EFO_0000217	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block F00-F09#F00-F09 Organic| including symptomatic| mental disorders	http://www.ebi.ac.uk/efo/EFO_0000677	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E119#Type 2 diabetes mellitus; Without complications	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23259#Arms tissue fat percentage	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23428#NMR Concentration of VLDL Particles	http://www.ebi.ac.uk/efo/EFO_0022152	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30100#Mean platelet (thrombocyte) volume	http://www.ebi.ac.uk/efo/EFO_0004584	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23339#Femur troch BMC (bone mineral content) (left)	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#Block D00-D09#D00-D09 In situ neoplasms	http://purl.obolibrary.org/obo/MONDO_0004647	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D509#Iron deficiency anaemia unspecified	http://purl.obolibrary.org/obo/HP_0001891	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Q65-Q79#Q65-Q79 Congenital malformations and deformations of the musculoskeletal system	http://www.ebi.ac.uk/efo/EFO_0009676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D47#Other neoplasms of uncertain or unknown behaviour of lymphoid haematopoietic and related tissue	http://www.ebi.ac.uk/efo/EFO_0001642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C56#Malignant neoplasm of ovary	http://www.ebi.ac.uk/efo/EFO_0003893	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#Block D37-D48#D37-D48 Neoplasms of uncertain or unknown behaviour	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#Block C60-C63#C60-C63 Malignant neoplasms of male genital organs	http://www.ebi.ac.uk/efo/EFO_0007355	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#Block C15-C26#C15-C26 Malignant neoplasms of digestive organs	http://purl.obolibrary.org/obo/MONDO_0002516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block A30-A49#A30-A49 Other bacterial diseases	http://www.ebi.ac.uk/efo/EFO_0000771	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23409#NMR Triglycerides in LDL	http://www.ebi.ac.uk/efo/EFO_0022320	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23268#Leg tissue fat percentage (left)	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25008#Volume of white matter	http://www.ebi.ac.uk/efo/EFO_0008320	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C184#Malignant neoplasm: Transverse colon	http://www.ebi.ac.uk/efo/EFO_1001950	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G060#Intracranial abscess and granuloma	http://www.ebi.ac.uk/efo/EFO_0009462	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1471#atrial fibrillation	http://www.ebi.ac.uk/efo/EFO_0000275	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G309#Alzheimer disease unspecified	http://purl.obolibrary.org/obo/MONDO_0004975	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K839#Disease of biliary tract unspecified	http://www.ebi.ac.uk/efo/EFO_0009534	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131303#Source of report of I23 certain current complications following acute myocardial infarction	http://www.ebi.ac.uk/efo/EFO_0008583	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C482#Malignant neoplasm: Peritoneum unspecified	http://purl.obolibrary.org/obo/MONDO_0002087	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C20#Malignant neoplasm of rectum	http://www.ebi.ac.uk/efo/EFO_1000657	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23109#Impedance of arm (right)	http://purl.obolibrary.org/obo/HP_0000924	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K626#Ulcer of anus and rectum	http://www.ebi.ac.uk/efo/EFO_0009685	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block D10-D36#D10-D36 Benign neoplasms	http://www.ebi.ac.uk/efo/EFO_0002422	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterXVII#Chapter XVII Congenital malformations| deformations and chromosomal abnormalities	http://purl.obolibrary.org/obo/MONDO_0021147	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K529#Noninfective gastroenteritis and colitis unspecified	http://www.ebi.ac.uk/efo/EFO_1001463	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesterol to Total Lipids in LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022238	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K22#Other diseases of oesophagus	http://www.ebi.ac.uk/efo/EFO_0009544	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C782#Secondary malignant neoplasm of pleura	http://www.ebi.ac.uk/efo/EFO_1000362	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I472#Ventricular tachycardia	http://www.ebi.ac.uk/efo/EFO_0005306	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#E349#Endocrine disorder unspecified	http://www.ebi.ac.uk/efo/EFO_0001379	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E78#Disorders of lipoprotein metabolism and other lipidaemias	http://www.ebi.ac.uk/efo/EFO_0000589	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block H40-H42#H40-H42 Glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G11#Hereditary ataxia	http://www.orpha.net/ORDO/Orphanet_183518	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block H25-H28#H25-H28 Disorders of lens	http://www.ebi.ac.uk/efo/EFO_0009674	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#Block C60-C63#C60-C63 Malignant neoplasms of male genital organs	http://purl.obolibrary.org/obo/MONDO_0024582	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#5#(9590-9999) Hematologic (Leukemias Lymphomas and related disorders)	http://purl.obolibrary.org/obo/MONDO_0044881	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1281#retinal detachment	http://www.ebi.ac.uk/efo/EFO_0005773	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1066#heart|cardiac problem	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1405#other renal|kidney problem	http://www.ebi.ac.uk/efo/EFO_0003086	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23501#NMR Triglycerides in Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022178	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I15#Secondary hypertension	http://www.ebi.ac.uk/efo/EFO_1002034	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C786#Secondary malignant neoplasm of retroperitoneum and peritoneum	http://www.ebi.ac.uk/efo/EFO_0007466	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131037#Source of report of G30 alzheimers disease	http://purl.obolibrary.org/obo/MONDO_0004975	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23424#NMR Total Lipids in VLDL	http://www.ebi.ac.uk/efo/EFO_0022175	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30040#Mean corpuscular volume	http://www.ebi.ac.uk/efo/EFO_0004526	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C480#Malignant neoplasm: Retroperitoneum	http://www.ebi.ac.uk/efo/EFO_0007466	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5264#Corneal hysteresis (left)	http://www.ebi.ac.uk/efo/EFO_0010066	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E86#Volume depletion	http://www.ebi.ac.uk/efo/EFO_0000589	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block E70-E90#E70-E90 Metabolic disorders	http://www.ebi.ac.uk/efo/EFO_0000589	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Z40-Z54#Z40-Z54 Persons encountering health services for specific procedures and health care	http://www.ebi.ac.uk/efo/EFO_0009786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block J90-J94#J90-J94 Other diseases of pleura	http://purl.obolibrary.org/obo/MONDO_0002037	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C349#Malignant neoplasm: Bronchus or lung unspecified	http://purl.obolibrary.org/obo/MONDO_0008903	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D123#Benign neoplasm: Transverse colon	http://purl.obolibrary.org/obo/MONDO_0002278	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23255#Arm tissue fat percentage (right)	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3761#Age hay fever rhinitis or eczema diagnosed	http://www.ebi.ac.uk/efo/EFO_0003956	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25205#Mean L1 in fornix on FA skeleton	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D25#Leiomyoma of uterus	http://purl.obolibrary.org/obo/HP_0000131	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M48#Other spondylopathies	http://www.ebi.ac.uk/efo/EFO_0004260	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#H271#Dislocation of lens	http://www.ebi.ac.uk/efo/EFO_0009674	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D23#Other benign neoplasms of skin	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D234#Benign neoplasm: Skin of scalp and neck	http://purl.obolibrary.org/obo/MONDO_0021440	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23567#NMR Phospholipids in Medium HDL	http://www.ebi.ac.uk/efo/EFO_0022295	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131721#Source of report of L20 atopic dermatitis	http://www.ebi.ac.uk/efo/EFO_0000274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K801#Calculus of gallbladder with other cholecystitis	http://www.ebi.ac.uk/efo/EFO_0004799	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D05#Carcinoma in situ of breast	http://www.ebi.ac.uk/efo/EFO_0000305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132015#Source of report of N08 glomerular disorders in DCE	http://www.ebi.ac.uk/efo/EFO_1002049	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z803#Family history of malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0009640	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23334#Femur total area (right)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block H30-H36#H30-H36 Disorders of choroid and retina	http://www.ebi.ac.uk/efo/EFO_0003839	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131675#Source of report of K80 cholelithiasis	http://www.ebi.ac.uk/efo/EFO_0004799	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130869#Source of report of F17 mental and behavioural disorders due to use of tobacco	http://www.ebi.ac.uk/efo/EFO_0000677	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#F05#Delirium not induced by alcohol and other psychoactive substances	http://www.ebi.ac.uk/efo/EFO_0009267	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K80#Cholelithiasis	http://www.ebi.ac.uk/efo/EFO_0004799	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I50#Heart failure	http://www.ebi.ac.uk/efo/EFO_0003144	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C43#Malignant melanoma of skin	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#Block C81-C96#C81-C96 Malignant neoplasms| stated or presumed to be primary| of lymphoid| haematopoietic and related tissue	http://purl.obolibrary.org/obo/MONDO_0002334	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z84#Family history of other conditions	http://snomed.info/id/SNOMED_281666001	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23618#NMR Triglycerides to Total Lipids in Large LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I21#Acute myocardial infarction	http://www.ebi.ac.uk/efo/EFO_0000612	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#F171#Mental and behavioural disorders due to use of tobacco; Harmful use	http://www.ebi.ac.uk/efo/EFO_0003768	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block D00-D09#D00-D09 In situ neoplasms	http://purl.obolibrary.org/obo/MONDO_0004647	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block K40-K46#K40-K46 Hernia	http://purl.obolibrary.org/obo/HP_0100790	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#4#(9380-9589) Nervous system	http://www.ebi.ac.uk/efo/EFO_0007392	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#ChapterII#Chapter II Neoplasms	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23444#NMR Omega-3 Fatty Acids	http://www.ebi.ac.uk/efo/EFO_0010119	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23435#NMR Triglycerides to Phosphoglycerides ratio	http://www.ebi.ac.uk/efo/EFO_0022327	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1136#liver|biliary|pancreas problem	http://www.ebi.ac.uk/efo/EFO_0003832	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1136#liver|biliary|pancreas problem	http://www.ebi.ac.uk/efo/EFO_0003832	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1136#liver|biliary|pancreas problem	http://www.ebi.ac.uk/efo/EFO_0001421	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23593#NMR Triglycerides to Total Lipids in Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022332	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23264#Gynoid tissue fat percentage	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130653#Source of report of D66 hereditary factor viii deficiency	http://www.ebi.ac.uk/efo/EFO_0000540	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1340#thalassaemia	http://www.ebi.ac.uk/efo/EFO_1001996	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H918#Other specified hearing loss	http://www.ebi.ac.uk/efo/EFO_0004238	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#L72#Follicular cysts of skin and subcutaneous tissue	http://www.ebi.ac.uk/efo/EFO_1001329	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M462#Osteomyelitis of vertebra	http://www.ebi.ac.uk/efo/EFO_0003102	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23400#NMR Total Cholesterol	http://www.ebi.ac.uk/efo/EFO_000457	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30840#Total bilirubin	http://www.ebi.ac.uk/efo/EFO_0004570	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C773#Secondary and unspecified malignant neoplasm: Axillary and upper limb lymph nodes	http://www.ebi.ac.uk/efo/EFO_0004906	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D56#Thalassaemia	http://www.ebi.ac.uk/efo/EFO_1001996	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#I420#Dilated cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q613#Polycystic kidney unspecified	http://www.ebi.ac.uk/efo/EFO_0008620	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C25#Malignant neoplasm of pancreas	http://www.ebi.ac.uk/efo/EFO_0002618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1588#hypertrophic cardiomyopathy (hcm | hocm)	http://www.ebi.ac.uk/efo/EFO_0000538	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R54#Senility	http://purl.obolibrary.org/obo/NBO_0000572	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z855#Personal history of malignant neoplasm of urinary tract	http://purl.obolibrary.org/obo/NCIT_C18849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23643#NMR Triglycerides to Total Lipids in Medium HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022333	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23595#NMR Cholesterol to Total Lipids in Medium VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022239	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25214#Mean L1 in cerebral peduncle on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3146#Speed of sound through heel	http://www.ebi.ac.uk/efo/EFO_0005654	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C900#Multiple myeloma	http://www.ebi.ac.uk/efo/EFO_0001378	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I73#Other peripheral vascular diseases	http://www.ebi.ac.uk/efo/EFO_0003875	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block J40-J47#J40-J47 Chronic lower respiratory diseases	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#A09#Other gastroenteritis and colitis of infectious and unspecified origin	http://www.ebi.ac.uk/efo/EFO_0010282	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C00#Malignant neoplasm of lip	http://www.ebi.ac.uk/efo/EFO_1001019	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23641#NMR Cholesteryl Esters to Total Lipids in Medium HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022251	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23628#NMR Triglycerides to Total Lipids in Small LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022337	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131457#Source of report of J18 pneumonia organism unspecified	http://www.ebi.ac.uk/efo/EFO_0003106	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23524#NMR Total Lipids in IDL	http://www.ebi.ac.uk/efo/EFO_0022161	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132051#Source of report of N28 other disorders of kidney and ureter not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0009690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131015#Source of report of G11 hereditary ataxia	http://www.orpha.net/ORDO/Orphanet_183518	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q85#Phakomatoses not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block R20-R23#R20-R23 Symptoms and signs involving the skin and subcutaneous tissue	http://www.ebi.ac.uk/efo/EFO_0003765	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23443#NMR Degree of Unsaturation	http://www.ebi.ac.uk/efo/EFO_0022261	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z804#Family history of malignant neoplasm of genital organs	http://www.ebi.ac.uk/efo/EFO_0009640	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23482#NMR Total Lipids in Chylomicrons and Extremely Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022306	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C921#Chronic myeloid leukaemia [CML] BCR|ABL-positive	http://www.ebi.ac.uk/efo/EFO_0000339	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I83#Varicose veins of lower extremities	http://purl.obolibrary.org/obo/HP_0002619	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q80#Congenital ichthyosis	http://purl.obolibrary.org/obo/MONDO_0019269	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterXVIII#Chapter XVIII Symptoms| signs and abnormal clinical and laboratory findings| not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0003765	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z491#Extracorporeal dialysis	http://www.ebi.ac.uk/efo/EFO_0010690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N39#Other disorders of urinary system	http://www.ebi.ac.uk/efo/EFO_0009690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23562#NMR Cholesteryl Esters in Large HDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	78#Heel bone mineral density (BMD) T-score automated	http://www.ebi.ac.uk/efo/EFO_0009270	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131313#Source of report of I28 other diseases of pulmonary vessels	http://www.ebi.ac.uk/efo/EFO_0009564	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131355#Source of report of I50 heart failure	http://www.ebi.ac.uk/efo/EFO_0003144	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30210#Eosinophill percentage	http://www.ebi.ac.uk/efo/EFO_0007991	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25357#Mean ICVF in superior cerebellar peduncle on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130697#Source of report of E03 other hypothyroidism	http://www.ebi.ac.uk/efo/EFO_0004705	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130799#Source of report of E70 disorders of aromatic amino acid metabolism	http://purl.obolibrary.org/obo/MONDO_0037871	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D680#Von Willebrand disease	http://www.orpha.net/ORDO/Orphanet_52530	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R000#Tachycardia unspecified	http://purl.obolibrary.org/obo/HP_0001649	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C50#Malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1093#pulmonary embolism +|- dvt	http://www.ebi.ac.uk/efo/EFO_0003827	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30690#Cholesterol	http://www.ebi.ac.uk/efo/EFO_0004574	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K66#Other disorders of peritoneum	http://www.ebi.ac.uk/efo/EFO_0008588	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K801#Calculus of gallbladder with other cholecystitis	http://www.ebi.ac.uk/efo/EFO_0004799	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K51#Ulcerative colitis	http://www.ebi.ac.uk/efo/EFO_0000729	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block I10-I15#I10-I15 Hypertensive diseases	http://www.ebi.ac.uk/efo/EFO_0000537	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C48#Malignant neoplasm of retroperitoneum and peritoneum	http://www.ebi.ac.uk/efo/EFO_0007466	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C60-C63#C60-C63 Malignant neoplasms of male genital organs	http://purl.obolibrary.org/obo/MONDO_0024582	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M7909#Rheumatism unspecified Site unspecified	http://www.ebi.ac.uk/efo/EFO_0005755	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K701#Alcoholic hepatitis	http://www.ebi.ac.uk/efo/EFO_1001345	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	6152#5#Blood clot in the leg (DVT)	http://purl.obolibrary.org/obo/HP_0001977	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23626#NMR Cholesteryl Esters to Total Lipids in Small LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022255	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22436#10P Liver PDFF (proton density fat fraction)	http://www.ebi.ac.uk/efo/EFO_0010821	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C445#Malignant neoplasm: Skin of trunk	http://purl.obolibrary.org/obo/MONDO_0002898	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I351#Aortic (valve) insufficiency	http://www.ebi.ac.uk/efo/EFO_0006818	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30750#Glycated haemoglobin (HbA1c)	http://www.ebi.ac.uk/efo/EFO_0004541	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D580#Hereditary spherocytosis	http://www.orpha.net/ORDO/Orphanet_822	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C79#Secondary malignant neoplasm of other and unspecified sites	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C57#Malignant neoplasm of other and unspecified female genital organs	http://www.ebi.ac.uk/efo/EFO_1001331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block E10-E14#E10-E14 Diabetes mellitus	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block I20-I25#I20-I25 Ischaemic heart diseases	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23491#NMR Cholesterol in Very Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022230	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D132#Benign neoplasm: Duodenum	http://www.ebi.ac.uk/efo/EFO_1000907	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C189#Malignant neoplasm: Colon unspecified	http://purl.obolibrary.org/obo/MONDO_0021063	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132031#Source of report of N17 acute renal failure	http://purl.obolibrary.org/obo/HP_0001919	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25592#Weighted-mean L1 in tract superior thalamic radiation (left)	http://www.ebi.ac.uk/efo/EFO_0006930	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N17#Acute renal failure	http://purl.obolibrary.org/obo/HP_0001919	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block E70-E90#E70-E90 Metabolic disorders	http://www.ebi.ac.uk/efo/EFO_0000589	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M77#Other enthesopathies	http://www.ebi.ac.uk/efo/EFO_0009666	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block B95-B98#B95-B98 Bacterial| viral and other infectious agents	http://www.ebi.ac.uk/efo/EFO_0005741	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23636#NMR Cholesteryl Esters to Total Lipids in Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022248	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23408#NMR Triglycerides in VLDL	http://www.ebi.ac.uk/efo/EFO_0022326	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23544#NMR Concentration of Small LDL Particles	http://www.ebi.ac.uk/efo/EFO_0022166	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I35#Nonrheumatic aortic valve disorders	http://www.ebi.ac.uk/efo/EFO_0009531	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23529#NMR Triglycerides in IDL	http://www.ebi.ac.uk/efo/EFO_0022149	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23502#NMR Concentration of Medium VLDL Particles	http://www.ebi.ac.uk/efo/EFO_0022152	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C770#Secondary and unspecified malignant neoplasm: Lymph nodes of head face and neck	http://www.ebi.ac.uk/efo/EFO_0004906	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23129#Trunk fat-free mass	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131541#Source of report of J93 pneumothorax	http://purl.obolibrary.org/obo/MONDO_0002076	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131183#Source of report of H35 other retinal disorders	http://www.ebi.ac.uk/efo/EFO_0003839	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#J189#Pneumonia unspecified	http://www.ebi.ac.uk/efo/EFO_0003106	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C50-C50#C50-C50 Malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	42021#Source of alzheimers disease report	http://purl.obolibrary.org/obo/MONDO_0004975	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E04#Other nontoxic goitre	http://www.ebi.ac.uk/efo/EFO_0004283	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#J841#Other interstitial pulmonary diseases with fibrosis	http://www.ebi.ac.uk/efo/EFO_0009448	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#E34#Other endocrine disorders	http://www.ebi.ac.uk/efo/EFO_0001379	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C64-C68#C64-C68 Malignant neoplasms of urinary tract	http://www.ebi.ac.uk/efo/EFO_1000363	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130709#Source of report of E11 non insulin dependent diabetes mellitus	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#C920#Acute myeloblastic leukaemia [AML]	http://www.ebi.ac.uk/efo/EFO_0000222	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N19#Unspecified kidney failure	http://www.ebi.ac.uk/efo/EFO_1002048	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C920#Acute myeloblastic leukaemia [AML]	http://www.ebi.ac.uk/efo/EFO_0000222	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1462#crohns disease	http://www.ebi.ac.uk/efo/EFO_0000384	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23325#Femur neck bone area (left)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23493#NMR Free Cholesterol in Very Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E784#Other hyperlipidaemia	http://purl.obolibrary.org/obo/HP_0003077	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J44#Other chronic obstructive pulmonary disease	http://www.ebi.ac.uk/efo/EFO_0000341	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C57#Malignant neoplasm of other and unspecified female genital organs	http://www.ebi.ac.uk/efo/EFO_1001331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter XVII#Chapter XVII Congenital malformations| deformations and chromosomal abnormalities	http://www.ebi.ac.uk/efo/EFO_0000336	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23411#NMR Total Phospholipids in Lipoprotein Particles	http://www.ebi.ac.uk/efo/EFO_0022315	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E113#Type 2 diabetes mellitus; With ophthalmic complications	http://www.ebi.ac.uk/efo/EFO_0009486	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23570#NMR Free Cholesterol in Medium HDL	http://www.ebi.ac.uk/efo/EFO_0022267	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C64-C68#C64-C68 Malignant neoplasms of urinary tract	http://www.ebi.ac.uk/efo/EFO_1000363	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#K57#Diverticular disease of intestine	http://www.ebi.ac.uk/efo/EFO_1001460	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C182#Malignant neoplasm: Ascending colon	http://www.ebi.ac.uk/efo/EFO_0004288	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25032#Median T2star in pallidum (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block F10-F19#F10-F19 Mental and behavioural disorders due to psychoactive substance use	http://www.ebi.ac.uk/efo/EFO_0000677	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	42019#Source of all cause dementia report	http://purl.obolibrary.org/obo/MONDO_0001627	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23458#NMR Polyunsaturated Fatty Acids to Monounsaturated Fatty Acids ratio	http://www.ebi.ac.uk/efo/EFO_0022302	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N039#Chronic nephritic syndrome; Unspecified	http://www.ebi.ac.uk/efo/EFO_0004255	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4124#Heel bone mineral density (BMD) (right)	http://www.ebi.ac.uk/efo/EFO_0009270	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K573#Diverticular disease of large intestine without perforation or abscess	http://purl.obolibrary.org/obo/MONDO_0024634	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C25#Malignant neoplasm of pancreas	http://www.ebi.ac.uk/efo/EFO_0002618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K12#Stomatitis and related lesions	http://www.ebi.ac.uk/efo/EFO_0009688	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G30#Alzheimer disease	http://purl.obolibrary.org/obo/MONDO_0004975	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K297#Gastritis unspecified	http://www.ebi.ac.uk/efo/EFO_0000217	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23568#NMR Cholesterol in Medium HDL	http://www.ebi.ac.uk/efo/EFO_0021903	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C259#Malignant neoplasm: Pancreas unspecified	http://www.ebi.ac.uk/efo/EFO_0002618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20150#Forced expiratory volume in 1-second (FEV1) Best measure	http://www.ebi.ac.uk/efo/EFO_0004314	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1438#polycythaemia vera	http://www.ebi.ac.uk/efo/EFO_0002429	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23582#NMR Free Cholesterol to Total Lipids in Chylomicrons and Extremely Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022232	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23541#NMR Cholesteryl Esters in Medium LDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25207#Mean L1 in corticospinal tract on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C449#Malignant neoplasm: Malignant neoplasm of skin unspecified	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C480#Malignant neoplasm: Retroperitoneum	http://www.ebi.ac.uk/efo/EFO_0007466	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25625#Weighted-mean L3 in tract anterior thalamic radiation (left)	http://www.ebi.ac.uk/efo/EFO_0006930	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#ChapterIX#Chapter IX Diseases of the circulatory system	http://www.ebi.ac.uk/efo/EFO_0000319	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z860#Personal history of other neoplasms	http://purl.obolibrary.org/obo/NCIT_C18849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesteryl Esters to Cholesterol in Chylomicrons and Extremely Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0021898	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30780#LDL direct	http://www.ebi.ac.uk/efo/EFO_0004611	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131671#Source of report of K76 other diseases of liver	http://www.ebi.ac.uk/efo/EFO_0001421	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25358#Mean ICVF in cerebral peduncle on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I500#Congestive heart failure	http://www.ebi.ac.uk/efo/EFO_0000373	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C93#Monocytic leukaemia	http://purl.obolibrary.org/obo/MONDO_0004600	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M85#Other disorders of bone density and structure	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C48#Malignant neoplasm of retroperitoneum and peritoneum	http://www.ebi.ac.uk/efo/EFO_0007466	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block K55-K64#K55-K64 Other diseases of intestines	http://www.ebi.ac.uk/efo/EFO_0009431	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23602#NMR Free Cholesterol to Total Lipids in Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022287	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I48#Atrial fibrillation and flutter	http://www.ebi.ac.uk/efo/EFO_0000275	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block J09-J18#J09-J18 Influenza and pneumonia	http://www.ebi.ac.uk/efo/EFO_0007328	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C92#Myeloid leukaemia	http://purl.obolibrary.org/obo/MONDO_0004643	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block N17-N19#N17-N19 Renal failure	http://purl.obolibrary.org/obo/HP_0001919	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23457#NMR Docosahexaenoic Acid to Total Fatty Acids percentage	http://www.ebi.ac.uk/efo/EFO_0022262	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#A09#Other gastroenteritis and colitis of infectious and unspecified origin	http://www.ebi.ac.uk/efo/EFO_1001463	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23342#Femur wards bone area (right)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25835#Volume of grey matter in Subcallosal Cortex (right)	http://www.ebi.ac.uk/efo/EFO_0005420	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25089#Mean FA in external capsule on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D133#Benign neoplasm: Other and unspecified parts of small intestine	http://purl.obolibrary.org/obo/MONDO_0004251	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C929#Myeloid leukaemia unspecified	http://purl.obolibrary.org/obo/MONDO_0004643	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#9950#Polycythemia vera	http://www.ebi.ac.uk/efo/EFO_0002429	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5256#Corneal hysteresis (right)	http://www.ebi.ac.uk/efo/EFO_0010066	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C92#Myeloid leukaemia	http://purl.obolibrary.org/obo/MONDO_0004643	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N02#Recurrent and persistent haematuria	http://purl.obolibrary.org/obo/HP_0000790	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block J95-J99#J95-J99 Other diseases of the respiratory system	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterII#Chapter II Neoplasms	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23244#Android bone mass	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I44#Atrioventricular and left bundle-branch block	http://www.ebi.ac.uk/efo/EFO_0004138	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23425#NMR Total Lipids in LDL	http://www.ebi.ac.uk/efo/EFO_0022308	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J181#Lobar pneumonia unspecified	http://www.ebi.ac.uk/efo/EFO_0003106	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#H409#Glaucoma unspecified	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I49#Other cardiac arrhythmias	http://www.ebi.ac.uk/efo/EFO_0004269	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D45#Polycythaemia vera	http://www.ebi.ac.uk/efo/EFO_0002429	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23547#NMR Cholesterol in Small LDL	http://www.ebi.ac.uk/efo/EFO_0022179	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C501#Malignant neoplasm: Central portion of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5098#6mm weak meridian (right)	http://www.ebi.ac.uk/efo/EFO_0004731	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K63#Other diseases of intestine	http://www.ebi.ac.uk/efo/EFO_0009431	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23470#NMR Glucose	http://www.ebi.ac.uk/efo/EFO_0004468	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23439#NMR Apolipoprotein B	http://www.ebi.ac.uk/efo/EFO_0004615	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23495#NMR Concentration of Large VLDL Particles	http://www.ebi.ac.uk/efo/EFO_0022173	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C504#Malignant neoplasm: Upper-outer quadrant of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K29#Gastritis and duodenitis	http://www.ebi.ac.uk/efo/EFO_0000217	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H353#Degeneration of macula and posterior pole	http://www.ebi.ac.uk/efo/EFO_0003839	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N319#Neuromuscular dysfunction of bladder unspecified	http://www.ebi.ac.uk/efo/EFO_1000018	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23464#NMR Total Concentration of Branched-Chain Amino Acids (Leucine + Isoleucine + Valine)	http://www.ebi.ac.uk/efo/EFO_0800662	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#B179#Acute viral hepatitis unspecified	http://www.ebi.ac.uk/efo/EFO_0004196	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23110#Impedance of arm (left)	http://purl.obolibrary.org/obo/HP_0000924	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131075#Source of report of G56 mononeuropathies of upper limb	http://www.ebi.ac.uk/efo/EFO_0009558	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132571#Source of report of Q80 congenital ichthyosis	http://www.orpha.net/ORDO/Orphanet_281097	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block R30-R39#R30-R39 Symptoms and signs involving the urinary system	http://purl.obolibrary.org/obo/HP_0000079	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23473#NMR Citrate	http://www.ebi.ac.uk/efo/EFO_0010114	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23548#NMR Cholesteryl Esters in Small LDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30660#Direct bilirubin	http://www.ebi.ac.uk/efo/EFO_0004570	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C169#Malignant neoplasm: Stomach unspecified	http://purl.obolibrary.org/obo/MONDO_0001056	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C446#Malignant neoplasm: Skin of upper limb including shoulder	http://purl.obolibrary.org/obo/MONDO_0002898	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C780#Secondary malignant neoplasm of lung	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter II#Chapter II Neoplasms	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D66#Hereditary factor VIII deficiency	http://www.orpha.net/ORDO/Orphanet_98878	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D638#Anaemia in other chronic diseases classified elsewhere	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C20#Malignant neoplasm of rectum	http://www.ebi.ac.uk/efo/EFO_1000657	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23449#NMR Linoleic Acid	http://www.ebi.ac.uk/efo/EFO_0006807	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23615#NMR Cholesterol to Total Lipids in Large LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022235	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23311#Spine bone area	http://www.ebi.ac.uk/efo/EFO_0004508	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23546#NMR Phospholipids in Small LDL	http://www.ebi.ac.uk/efo/EFO_0022297	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3786#Age asthma diagnosed	http://www.ebi.ac.uk/efo/EFO_0004918	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25359#Mean ICVF in cerebral peduncle on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C90#Multiple myeloma and malignant plasma cell neoplasms	http://www.ebi.ac.uk/efo/EFO_0001378	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I28#Other diseases of pulmonary vessels	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1275#retinal problem	http://www.ebi.ac.uk/efo/EFO_0003839	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23404#NMR Clinical LDL Cholesterol	http://www.ebi.ac.uk/efo/EFO_0004195	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23494#NMR Triglycerides in Very Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022325	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30710#C-reactive protein	http://www.ebi.ac.uk/efo/EFO_0004458	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20008#Interpolated Year when non-cancer illness first diagnosed	http://www.ebi.ac.uk/efo/EFO_0000408	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H409#Glaucoma unspecified	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I458#Other specified conduction disorders	http://www.ebi.ac.uk/efo/EFO_0005137	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D12#Benign neoplasm of colon rectum anus and anal canal	http://www.ebi.ac.uk/efo/EFO_0003835	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I82#Other venous embolism and thrombosis	http://purl.obolibrary.org/obo/HP_0030242	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K91#Postprocedural disorders of digestive system not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#M200#Deformity of finger(s)	http://purl.obolibrary.org/obo/HP_0001167	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Q20-Q28#Q20-Q28 Congenital malformations of the circulatory system	http://purl.obolibrary.org/obo/MONDO_0024239	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K43#Ventral hernia	http://www.ebi.ac.uk/efo/EFO_1001866	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23623#NMR Triglycerides to Total Lipids in Medium LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022334	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30080#Platelet count	http://www.ebi.ac.uk/efo/EFO_0004309	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23619#NMR Phospholipids to Total Lipids in Medium LDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22420#LV ejection fraction	http://www.ebi.ac.uk/efo/EFO_0005527	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	2443#Diabetes diagnosed by doctor	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131083#Source of report of G60 hereditary and idiopathic neuropathy	http://www.ebi.ac.uk/efo/EFO_0004149	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131387#Source of report of I73 other peripheral vascular diseases	http://www.ebi.ac.uk/efo/EFO_0003875	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C60-C63#C60-C63 Malignant neoplasms of male genital organs	http://www.ebi.ac.uk/efo/EFO_0007355	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I26#Pulmonary embolism	http://www.ebi.ac.uk/efo/EFO_0003827	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K50#Crohn disease [regional enteritis]	http://www.ebi.ac.uk/efo/EFO_0000384	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block D70-D77#D70-D77 Other diseases of blood and blood-forming organs	http://www.ebi.ac.uk/efo/EFO_0005803	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z824#Family history of ischaemic heart disease and other diseases of the circulatory system	http://purl.obolibrary.org/obo/NCIT_C167449	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block A00-A09#A00-A09 Intestinal infectious diseases	http://purl.obolibrary.org/obo/MONDO_0000916	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C436#Malignant neoplasm: Malignant melanoma of upper limb including shoulder	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#Block F00-F09#F00-F09 Organic| including symptomatic| mental disorders	http://www.ebi.ac.uk/efo/EFO_0000677	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131215#Source of report of H55 nystagmus and other irregular eye movements	http://www.ebi.ac.uk/efo/EFO_0003966	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5265#Corneal resistance factor (left)	http://www.ebi.ac.uk/efo/EFO_0010067	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#Block J80-J84#J80-J84 Other respiratory diseases principally affecting the interstitium	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5078#logMAR in round (left)	http://snomed.info/id/SNOMED_413077008	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23556#NMR Free Cholesterol in Very Large HDL	http://www.ebi.ac.uk/efo/EFO_0022273	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	42015#Source of asthma report	http://purl.obolibrary.org/obo/MONDO_0004979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23506#NMR Cholesteryl Esters in Medium VLDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30140#Neutrophill count	http://www.ebi.ac.uk/efo/EFO_0004833	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C911#Chronic lymphocytic leukaemia of B-cell type	http://www.ebi.ac.uk/efo/EFO_0000095	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R18#Ascites	http://purl.obolibrary.org/obo/HP_0001541	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R21#Rash and other nonspecific skin eruption	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D68#Other coagulation defects	http://www.ebi.ac.uk/efo/EFO_0009314	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q12#Congenital lens malformations	http://purl.obolibrary.org/obo/HP_0000517	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1309#osteoporosis	http://www.ebi.ac.uk/efo/EFO_0003882	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30860#Total protein	http://www.ebi.ac.uk/efo/EFO_0004536	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23530#NMR Concentration of Large LDL Particles	http://www.ebi.ac.uk/efo/EFO_0022160	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23100#Whole body fat mass	http://www.ebi.ac.uk/efo/EFO_0005409	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23558#NMR Concentration of Large HDL Particles	http://www.ebi.ac.uk/efo/EFO_0022188	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4079#Diastolic blood pressure automated reading	http://www.ebi.ac.uk/efo/EFO_0006336	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#ChapterV#Chapter V Mental and behavioural disorders	http://www.ebi.ac.uk/efo/EFO_0000677	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z09#Follow-up examination after treatment for conditions other than malignant neoplasms	http://www.ebi.ac.uk/efo/EFO_0009642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K62#Other diseases of anus and rectum	http://www.ebi.ac.uk/efo/EFO_0009685	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N184#Chronic kidney disease stage 4	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D45#Polycythaemia vera	http://www.ebi.ac.uk/efo/EFO_0002429	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C47#Malignant neoplasm of peripheral nerves and autonomic nervous system	http://www.ebi.ac.uk/efo/EFO_0007392	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23624#NMR Phospholipids to Total Lipids in Small LDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23126#Arm predicted mass (left)	http://www.ebi.ac.uk/efo/EFO_0004302	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23605#NMR Cholesterol to Total Lipids in Very Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022245	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23340#Femur troch BMC (bone mineral content) (right)	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N281#Cyst of kidney	http://www.ebi.ac.uk/efo/EFO_0008616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131105#Source of report of G82 paraplegia and tetraplegia	http://www.ebi.ac.uk/efo/EFO_0009679	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D58#Other hereditary haemolytic anaemias	http://purl.obolibrary.org/obo/HP_0004804	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#H269#Cataract unspecified	http://purl.obolibrary.org/obo/MONDO_0005129	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#Block C50-C50#C50-C50 Malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23471#NMR Lactate	http://www.ebi.ac.uk/efo/EFO_0007745	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23447#NMR Monounsaturated Fatty Acids	http://www.ebi.ac.uk/efo/EFO_0022187	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30650#Aspartate aminotransferase	http://www.ebi.ac.uk/efo/EFO_0004736	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L20#Atopic dermatitis	http://www.ebi.ac.uk/efo/EFO_0000274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K76#Other diseases of liver	http://www.ebi.ac.uk/efo/EFO_0001421	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block D10-D36#D10-D36 Benign neoplasms	http://www.ebi.ac.uk/efo/EFO_0002422	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z49#Care involving dialysis	http://www.ebi.ac.uk/efo/EFO_1002048	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23629#NMR Phospholipids to Total Lipids in Very Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23578#NMR Triglycerides in Small HDL	http://www.ebi.ac.uk/efo/EFO_0022158	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23240#Trunk BMC (bone mineral content)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23202#L1-L4 average width	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20162#Pack years adult smoking as proportion of life span exposed to smoking	http://www.ebi.ac.uk/efo/EFO_0005671	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23222#Arm BMC (bone mineral content) (right)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I781#Naevus non-neoplastic	http://purl.obolibrary.org/obo/MONDO_0001574	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#H400#Glaucoma suspect	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q85#Phakomatoses not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block D60-D64#D60-D64 Aplastic and other anaemias	http://purl.obolibrary.org/obo/HP_0001915	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#H401#Primary open-angle glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterXXI#Chapter XXI Factors influencing health status and contact with health services	http://www.ebi.ac.uk/efo/EFO_0009786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	2227#Other eye problems	http://www.ebi.ac.uk/efo/EFO_0003966	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130647#Source of report of D63 anaemia in chronic DCE	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131307#Source of report of I25 chronic ischaemic heart disease	http://www.ebi.ac.uk/efo/EFO_0001645	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25031#Median T2star in putamen (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G821#Spastic paraplegia	http://purl.obolibrary.org/obo/HP_0001258	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#Block C50-C50#C50-C50 Malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22146#Age hayfever or allergic rhinitis diagnosed by doctor	http://www.ebi.ac.uk/efo/EFO_0005854	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I71#Aortic aneurysm and dissection	http://www.ebi.ac.uk/efo/EFO_0001666	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1461#inflammatory bowel disease	http://www.ebi.ac.uk/efo/EFO_0003767	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I209#Angina pectoris unspecified	http://www.ebi.ac.uk/efo/EFO_0003913	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23606#NMR Cholesteryl Esters to Total Lipids in Very Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022259	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23545#NMR Total Lipids in Small LDL	http://www.ebi.ac.uk/efo/EFO_0022168	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23538#NMR Total Lipids in Medium LDL	http://www.ebi.ac.uk/efo/EFO_0022180	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23203#L1-L4 BMC (bone mineral content)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D133#Benign neoplasm: Other and unspecified parts of small intestine	http://purl.obolibrary.org/obo/MONDO_0004251	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23504#NMR Phospholipids in Medium VLDL	http://www.ebi.ac.uk/efo/EFO_0022154	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L721#Trichilemmal cyst	http://www.ebi.ac.uk/efo/EFO_1001329	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C43-C44#C43-C44 Melanoma and other malignant neoplasms of skin	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M0637#Rheumatoid nodule Ankle and foot	http://purl.obolibrary.org/obo/NCIT_C197296	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23535#NMR Free Cholesterol in Large LDL	http://www.ebi.ac.uk/efo/EFO_0022176	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block R10-R19#R10-R19 Symptoms and signs involving the digestive system and abdomen	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23313#Arm bone area (left)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25028#Median T2star in caudate (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N27#Small kidney of unknown cause	http://www.ebi.ac.uk/efo/EFO_0009471	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesteryl Esters to Cholesterol in VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022250	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23200#L1-L4 area	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30090#Platelet crit	http://www.ebi.ac.uk/efo/EFO_0007985	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23115#Leg fat percentage (left)	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E039#Hypothyroidism unspecified	http://www.ebi.ac.uk/efo/EFO_0004705	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I151#Hypertension secondary to other renal disorders	http://www.ebi.ac.uk/efo/EFO_1002039	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C48#Malignant neoplasm of retroperitoneum and peritoneum	http://www.ebi.ac.uk/efo/EFO_0007466	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#R040#Epistaxis	http://www.ebi.ac.uk/efo/EFO_0003895	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D68#Other coagulation defects	http://www.ebi.ac.uk/efo/EFO_0009314	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D69#Purpura and other haemorrhagic conditions	http://purl.obolibrary.org/obo/HP_0000979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block I60-I69#I60-I69 Cerebrovascular diseases	http://www.ebi.ac.uk/efo/EFO_0003763	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131343#Source of report of I44 atrioventricular and left bundle branch block	http://www.ebi.ac.uk/efo/EFO_0004138	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23500#NMR Free Cholesterol in Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022265	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23431#NMR Average Diameter for VLDL Particles	http://www.ebi.ac.uk/efo/EFO_0008594	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E349#Endocrine disorder unspecified	http://www.ebi.ac.uk/efo/EFO_0001379	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M10#Gout	http://www.ebi.ac.uk/efo/EFO_0004274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L209#Atopic dermatitis unspecified	http://www.ebi.ac.uk/efo/EFO_0000274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C43#Malignant melanoma of skin	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1497#pneumothorax	http://purl.obolibrary.org/obo/MONDO_0002076	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23627#NMR Free Cholesterol to Total Lipids in Small LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022286	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22403#Anterior thigh fat-free muscle volume (right)	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D22#Melanocytic naevi	http://www.ebi.ac.uk/efo/EFO_0009675	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131397#Source of report of I80 phlebitis and thrombophlebitis	http://www.ebi.ac.uk/efo/EFO_1001395	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25553#Weighted-mean MO in tract forceps minor	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block D70-D77#D70-D77 Other diseases of blood and blood-forming organs	http://www.ebi.ac.uk/efo/EFO_0005803	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C77#Secondary and unspecified malignant neoplasm of lymph nodes	http://www.ebi.ac.uk/efo/EFO_0004906	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C25#Malignant neoplasm of pancreas	http://www.ebi.ac.uk/efo/EFO_0002618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block L60-L75#L60-L75 Disorders of skin appendages	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block J90-J94#J90-J94 Other diseases of pleura	http://purl.obolibrary.org/obo/MONDO_0002037	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block D60-D64#D60-D64 Aplastic and other anaemias	http://purl.obolibrary.org/obo/HP_0001915	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block E65-E68#E65-E68 Obesity and other hyperalimentation	http://www.ebi.ac.uk/efo/EFO_0001073	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23584#NMR Phospholipids to Total Lipids in Very Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25338#Mean L3 in superior fronto-occipital fasciculus on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23492#NMR Cholesteryl Esters in Very Large VLDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23336#Femur total BMC (bone mineral content) (right)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30630#Apolipoprotein A	http://www.ebi.ac.uk/efo/EFO_0004732	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D474#Osteomyelofibrosis	http://www.ebi.ac.uk/efo/EFO_0002430	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H905#Sensorineural hearing loss unspecified	http://www.ebi.ac.uk/efo/EFO_1001176	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25687#Weighted-mean OD in tract forceps major	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25363#Mean ICVF in posterior limb of internal capsule on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C798#Secondary malignant neoplasm of other specified sites	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I269#Pulmonary embolism without mention of acute cor pulmonale	http://www.ebi.ac.uk/efo/EFO_0003827	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1434#other neurological problem	http://www.ebi.ac.uk/efo/EFO_0000618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Total Triglycerides to Total Lipids percentage	http://www.ebi.ac.uk/efo/EFO_0020947	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23427#NMR Total Concentration of Lipoprotein Particles	http://www.ebi.ac.uk/efo/EFO_0004732	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D352#Benign neoplasm: Pituitary gland	http://purl.obolibrary.org/obo/NCIT_C3330	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23486#NMR Free Cholesterol in Chylomicrons and Extremely Large VLDL	http://www.ebi.ac.uk/efo/EFO_0021898	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23420#NMR Free Cholesterol in VLDL	http://www.ebi.ac.uk/efo/EFO_0022276	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130821#Source of report of E83 disorders of mineral metabolism	http://www.ebi.ac.uk/efo/EFO_0009556	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131495#Source of report of J45 asthma	http://purl.obolibrary.org/obo/MONDO_0004979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I120#Hypertensive renal disease with renal failure	http://purl.obolibrary.org/obo/MONDO_0024633	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter XIV#Chapter XIV Diseases of the genitourinary system	http://www.ebi.ac.uk/efo/EFO_0009663	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#J93#Pneumothorax	http://purl.obolibrary.org/obo/MONDO_0002076	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23402#NMR Remnant Cholesterol (Non-HDL Non-LDL -Cholesterol)	http://www.ebi.ac.uk/efo/EFO_0010815	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D42#Neoplasm of uncertain or unknown behaviour of meninges	http://www.ebi.ac.uk/efo/EFO_0003851	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23634#NMR Phospholipids to Total Lipids in Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23590#NMR Cholesterol to Total Lipids in Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022236	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23101#Whole body fat-free mass	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M200#Deformity of finger(s)	http://purl.obolibrary.org/obo/HP_0001167	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25360#Mean ICVF in anterior limb of internal capsule on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H355#Hereditary retinal dystrophy	http://www.orpha.net/ORDO/Orphanet_71862	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block I95-I99#I95-I99 Other and unspecified disorders of the circulatory system	http://www.ebi.ac.uk/efo/EFO_0000319	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23465#NMR Isoleucine	http://www.ebi.ac.uk/efo/EFO_0009793	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23422#NMR Free Cholesterol in HDL	http://www.ebi.ac.uk/efo/EFO_0022264	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23536#NMR Triglycerides in Large LDL	http://www.ebi.ac.uk/efo/EFO_0022319	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block I30-I52#I30-I52 Other forms of heart disease	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131393#Source of report of I78 diseases of capillaries	http://www.ebi.ac.uk/efo/EFO_0004264	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130637#Source of report of D58 other hereditary haemolytic anaemias	http://www.ebi.ac.uk/efo/EFO_0005558	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I42#Cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q850#Neurofibromatosis (nonmalignant)	http://www.ebi.ac.uk/efo/EFO_0008514	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23429#NMR Concentration of LDL Particles	http://www.ebi.ac.uk/efo/EFO_0022166	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C775#Secondary and unspecified malignant neoplasm: Intrapelvic lymph nodes	http://www.ebi.ac.uk/efo/EFO_0004906	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C927#Other myeloid leukaemia	http://purl.obolibrary.org/obo/MONDO_0004643	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q44#Congenital malformations of gallbladder bile ducts and liver	http://purl.obolibrary.org/obo/HP_0001392	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L40#Psoriasis	http://www.ebi.ac.uk/efo/EFO_0000676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20007#Interpolated Age of participant when cancer first diagnosed	http://www.ebi.ac.uk/efo/EFO_0000311	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter X#Chapter X Diseases of the respiratory system	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1094#deep venous thrombosis (dvt)	http://www.ebi.ac.uk/efo/EFO_0003907	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K590#Constipation	http://purl.obolibrary.org/obo/MONDO_0002203	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z856#Personal history of leukaemia	http://www.ebi.ac.uk/efo/EFO_0000565	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23442#NMR Total Fatty Acids	http://www.ebi.ac.uk/efo/EFO_0005110	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23519#NMR Cholesterol in Very Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022231	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C541#Malignant neoplasm: Endometrium	http://purl.obolibrary.org/obo/MONDO_0011962	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23276#Legs tissue fat percentage	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25356#Mean ICVF in superior cerebellar peduncle on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J93#Pneumothorax	http://purl.obolibrary.org/obo/MONDO_0002076	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1079#cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23645#NMR Cholesterol to Total Lipids in Small HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022240	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesteryl Esters to Total Lipids in HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022251	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C83#Non-follicular lymphoma	http://www.ebi.ac.uk/efo/EFO_0005952	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23505#NMR Cholesterol in Medium VLDL	http://www.ebi.ac.uk/efo/EFO_0022225	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25077#Mean FA in retrolenticular part of internal capsule on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C502#Malignant neoplasm: Upper-inner quadrant of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D561#Beta thalassaemia	http://purl.obolibrary.org/obo/MONDO_0019402	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q613#Polycystic kidney unspecified	http://www.ebi.ac.uk/efo/EFO_0008620	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I421#Obstructive hypertrophic cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000538	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block D65-D69#D65-D69 Coagulation defects| purpura and other haemorrhagic conditions	http://purl.obolibrary.org/obo/MONDO_0002243	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I898#Other specified noninfective disorders of lymphatic vessels and lymph nodes	http://www.ebi.ac.uk/efo/EFO_0007352	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R590#Localized enlarged lymph nodes	http://purl.obolibrary.org/obo/HP_0002716	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130661#Source of report of D70 agranulocytosis	http://purl.obolibrary.org/obo/HP_0012234	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#R070#Pain in throat	http://www.ebi.ac.uk/efo/EFO_0003843	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M16#Coxarthrosis [arthrosis of hip]	http://www.ebi.ac.uk/efo/EFO_1000786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132581#Source of report of Q85 phakomatoses not elsewhere classified	http://purl.obolibrary.org/obo/MONDO_0042983	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D461#Refractory anaemia with ring sideroblasts	http://www.ebi.ac.uk/efo/EFO_0003811	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D473#Essential (haemorrhagic) thrombocythaemia	http://www.ebi.ac.uk/efo/EFO_0000479	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25438#Mean OD in tapetum on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1077#heart arrhythmia	http://www.ebi.ac.uk/efo/EFO_0004269	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1048#leukaemia	http://www.ebi.ac.uk/efo/EFO_0000565	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130071#Source of report of A41 other septicaemia	http://purl.obolibrary.org/obo/HP_0100806	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23622#NMR Free Cholesterol to Total Lipids in Medium LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022283	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23648#NMR Triglycerides to Total Lipids in Small HDL percentage	http://purl.obolibrary.org/obo/MONDO_0004251	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23515#NMR Triglycerides in Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022145	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D128#Benign neoplasm: Rectum	http://purl.obolibrary.org/obo/MONDO_0021462	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23102#Whole body water mass	http://www.ebi.ac.uk/efo/EFO_0009805	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C54#Malignant neoplasm of corpus uteri	http://www.ebi.ac.uk/efo/EFO_0007532	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1452#eczema|dermatitis	http://purl.obolibrary.org/obo/MONDO_0002406	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132513#Source of report of Q44 congenital malformations of gallbladder bile ducts and liver	http://purl.obolibrary.org/obo/HP_0001392	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D233#Benign neoplasm: Skin of other and unspecified parts of face	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q612#Polycystic kidney autosomal dominant	http://www.ebi.ac.uk/efo/EFO_0008620	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C250#Malignant neoplasm: Head of pancreas	http://www.ebi.ac.uk/efo/EFO_0002618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23113#Leg fat-free mass (right)	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131493#Source of report of J44 other chronic obstructive pulmonary disease	http://www.ebi.ac.uk/efo/EFO_0000341	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4122#Speed of sound through heel (right)	http://www.ebi.ac.uk/efo/EFO_0005654	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D696#Thrombocytopenia unspecified	http://purl.obolibrary.org/obo/HP_0001873	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G60#Hereditary and idiopathic neuropathy	http://www.ebi.ac.uk/efo/EFO_0004149	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N28#Other disorders of kidney and ureter not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0009690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterIX#Chapter IX Diseases of the circulatory system	http://www.ebi.ac.uk/efo/EFO_0000319	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C259#Malignant neoplasm: Pancreas unspecified	http://www.ebi.ac.uk/efo/EFO_1000359	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5132#3mm strong meridian (right)	http://www.ebi.ac.uk/efo/EFO_0004731	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I422#Other hypertrophic cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000538	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D259#Leiomyoma of uterus unspecified	http://purl.obolibrary.org/obo/HP_0000131	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23295#Femur troch BMD (bone mineral density) (left)	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23098#Weight	http://www.ebi.ac.uk/efo/EFO_0004338	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23647#NMR Free Cholesterol to Total Lipids in Small HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022285	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block I30-I52#I30-I52 Other forms of heart disease	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23509#NMR Concentration of Small VLDL Particles	http://www.ebi.ac.uk/efo/EFO_0022147	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23327#Femur neck BMC (bone mineral content) (left)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22127#Doctor diagnosed asthma	http://purl.obolibrary.org/obo/MONDO_0004979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130827#Source of report of E86 volume depletion	http://www.ebi.ac.uk/efo/EFO_0000589	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N189#Chronic kidney disease unspecified	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C50#Malignant neoplasm of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1224#thyroid problem (not cancer)	http://www.ebi.ac.uk/efo/EFO_1000627	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23487#NMR Triglycerides in Chylomicrons and Extremely Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022316	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23610#NMR Cholesterol to Total Lipids in IDL percentage	http://www.ebi.ac.uk/efo/EFO_0022233	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23588#NMR Triglycerides to Total Lipids in Very Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022340	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C502#Malignant neoplasm: Upper-inner quadrant of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N189#Chronic kidney disease unspecified	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25199#Mean MO in tapetum on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C508#Malignant neoplasm: Overlapping lesion of breast	http://www.ebi.ac.uk/efo/EFO_0003869	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132003#Source of report of N02 recurrent and persistent haematuria	http://purl.obolibrary.org/obo/HP_0000790	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#R50#Fever of other and unknown origin	http://www.ebi.ac.uk/efo/EFO_0003952	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#M472#Other spondylosis with radiculopathy	http://purl.obolibrary.org/obo/MONDO_0002253	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#9861#Acute myeloid leukemia NOS	http://www.ebi.ac.uk/efo/EFO_1001934	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C81-C96#C81-C96 Malignant neoplasms| stated or presumed to be primary| of lymphoid| haematopoietic and related tissue	http://purl.obolibrary.org/obo/MONDO_0002334	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block Q20-Q28#Q20-Q28 Congenital malformations of the circulatory system	http://purl.obolibrary.org/obo/MONDO_0024239	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1192#renal|kidney failure	http://www.ebi.ac.uk/efo/EFO_1002048	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22190#Unadjusted T/S ratio	http://www.ebi.ac.uk/efo/EFO_0004505	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	osteoarthritis, hip	http://www.ebi.ac.uk/efo/EFO_0022291	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Free Cholesterol to Cholesterol in HDL percentage	http://www.ebi.ac.uk/efo/EFO_0007931	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block M95-M99#M95-M99 Other disorders of the musculoskeletal system and connective tissue	http://www.ebi.ac.uk/efo/EFO_0009676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D489#Neoplasm of uncertain or unknown behaviour: Neoplasm of uncertain or unknown behaviour unspecified	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23489#NMR Total Lipids in Very Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022175	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23119#Arm fat percentage (right)	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I509#Heart failure unspecified	http://www.ebi.ac.uk/efo/EFO_0003144	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H400#Glaucoma suspect	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C80#Malignant neoplasm without specification of site	http://www.ebi.ac.uk/efo/EFO_0000311	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block D50-D53#D50-D53 Nutritional anaemias	http://www.ebi.ac.uk/efo/EFO_0001069	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#Block C81-C96#C81-C96 Malignant neoplasms| stated or presumed to be primary| of lymphoid| haematopoietic and related tissue	http://purl.obolibrary.org/obo/MONDO_0002334	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block I70-I79#I70-I79 Diseases of arteries| arterioles and capillaries	http://purl.obolibrary.org/obo/MONDO_0001574	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1040#uterine|endometrial cancer	http://www.ebi.ac.uk/efo/EFO_0002919	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterI#Chapter I Certain infectious and parasitic diseases	http://www.ebi.ac.uk/efo/EFO_0001067	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M255#Pain in joint	http://www.ebi.ac.uk/efo/EFO_1000999	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#A419#Sepsis unspecified	http://purl.obolibrary.org/obo/HP_0100806	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23639#NMR Phospholipids to Total Lipids in Medium HDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z867#Personal history of diseases of the circulatory system	http://snomed.info/id/SNOMED_281666001	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D131#Benign neoplasm: Stomach	http://purl.obolibrary.org/obo/MONDO_0021449	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23560#NMR Phospholipids in Large HDL	http://www.ebi.ac.uk/efo/EFO_0022190	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3062#Forced vital capacity (FVC)	http://www.ebi.ac.uk/efo/EFO_0004312	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R50#Fever of other and unknown origin	http://www.ebi.ac.uk/efo/EFO_0003952	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132481#Source of report of Q27 other congenital malformations of peripheral vascular system	http://purl.obolibrary.org/obo/HP_0002597	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I802#Phlebitis and thrombophlebitis of other deep vessels of lower extremities	http://purl.obolibrary.org/obo/HP_0004418	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I51#Complications and ill-defined descriptions of heart disease	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#9960#Chronic myeloproliferative disease NOS	http://www.ebi.ac.uk/efo/EFO_0002428	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block D37-D48#D37-D48 Neoplasms of uncertain or unknown behaviour	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D13#Benign neoplasm of other and ill-defined parts of digestive system	http://www.ebi.ac.uk/efo/EFO_0008549	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#H26#Other cataract	http://purl.obolibrary.org/obo/MONDO_0005129	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#ChapterII#Chapter II Neoplasms	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C509#Malignant neoplasm: Breast unspecified	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23522#NMR Triglycerides in Very Small VLDL	http://www.ebi.ac.uk/efo/EFO_0022144	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20019#Speech-reception-threshold (SRT) estimate (left)	http://www.ebi.ac.uk/efo/EFO_0007616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I25#Chronic ischaemic heart disease	http://www.ebi.ac.uk/efo/EFO_0001645	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C78#Secondary malignant neoplasm of respiratory and digestive organs	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23417#NMR Cholesteryl Esters in LDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C180#Malignant neoplasm: Caecum	http://purl.obolibrary.org/obo/MONDO_0002033	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23112#Leg fat mass (right)	http://www.ebi.ac.uk/efo/EFO_0005409	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N281#Cyst of kidney	http://www.ebi.ac.uk/efo/EFO_0008616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C787#Secondary malignant neoplasm of liver and intrahepatic bile duct	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I09#Other rheumatic heart diseases	http://www.ebi.ac.uk/efo/EFO_1001161	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#C90#Multiple myeloma and malignant plasma cell neoplasms	http://www.ebi.ac.uk/efo/EFO_0001378	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I12#Hypertensive renal disease	http://purl.obolibrary.org/obo/MONDO_0024633	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C92#Myeloid leukaemia	http://purl.obolibrary.org/obo/MONDO_0004643	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#Block C15-C26#C15-C26 Malignant neoplasms of digestive organs	http://www.ebi.ac.uk/efo/EFO_0008549	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N08#Glomerular disorders in diseases classified elsewhere	http://www.ebi.ac.uk/efo/EFO_1002049	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23338#Femur troch bone area (right)	http://www.ebi.ac.uk/efo/EFO_0003923	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30200#Neutrophill percentage	http://www.ebi.ac.uk/efo/EFO_0007990	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30110#Platelet distribution width	http://www.ebi.ac.uk/efo/EFO_0007984	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H91#Other hearing loss	http://www.ebi.ac.uk/efo/EFO_0004238	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter V#Chapter V Mental and behavioural disorders	http://www.ebi.ac.uk/efo/EFO_0000677	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N762#Acute vulvitis	http://www.ebi.ac.uk/efo/EFO_1001239	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block K55-K64#K55-K64 Other diseases of intestines	http://www.ebi.ac.uk/efo/EFO_0009431	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block N25-N29#N25-N29 Other disorders of kidney and ureter	http://www.ebi.ac.uk/efo/EFO_0009690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1255#peripheral neuropathy	http://www.ebi.ac.uk/efo/EFO_0003100	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#ChapterX#Chapter X Diseases of the respiratory system	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23401#NMR Total Cholesterol Minus HDL-C	http://www.ebi.ac.uk/efo/EFO_0005689	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterXII#Chapter XII Diseases of the skin and subcutaneous tissue	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C959#Leukaemia unspecified	http://www.ebi.ac.uk/efo/EFO_0000565	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	102#Pulse rate automated reading	http://www.ebi.ac.uk/efo/EFO_0004326	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#E04#Other nontoxic goitre	http://www.ebi.ac.uk/efo/EFO_0004283	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I78#Diseases of capillaries	http://www.ebi.ac.uk/efo/EFO_0004264	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q273#Peripheral arteriovenous malformation	http://purl.obolibrary.org/obo/MONDO_0001256	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#R944#Abnormal results of kidney function studies	http://www.ebi.ac.uk/efo/EFO_0009628	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#M20#Acquired deformities of fingers and toes	http://purl.obolibrary.org/obo/HP_0011297	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1445#clotting disorder|excessive bleeding	http://www.ebi.ac.uk/efo/EFO_0009314	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30880#Urate	http://www.ebi.ac.uk/efo/EFO_0004531	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H029#Disorder of eyelid unspecified	http://www.ebi.ac.uk/efo/EFO_0009547	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23413#NMR Phospholipids in LDL	http://www.ebi.ac.uk/efo/EFO_0022294	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20022#Birth weight	http://www.ebi.ac.uk/efo/EFO_0004344	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23490#NMR Phospholipids in Very Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022299	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23272#Leg tissue fat percentage (right)	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C509#Malignant neoplasm: Breast unspecified	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132035#Source of report of N19 unspecified renal failure	http://www.ebi.ac.uk/efo/EFO_1002048	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25882#Volume of grey matter in Putamen (left)	http://www.ebi.ac.uk/efo/EFO_0005420	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C449#Malignant neoplasm: Malignant neoplasm of skin unspecified	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block H25-H28#H25-H28 Disorders of lens	http://www.ebi.ac.uk/efo/EFO_0009674	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block A00-A09#A00-A09 Intestinal infectious diseases	http://purl.obolibrary.org/obo/MONDO_0000916	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23583#NMR Triglycerides to Total Lipids in Chylomicrons and Extremely Large VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022328	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	6152#9#Hayfever allergic rhinitis or eczema	http://www.ebi.ac.uk/efo/EFO_0003956	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30060#Mean corpuscular haemoglobin concentration	http://www.ebi.ac.uk/efo/EFO_0004528	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131291#Source of report of I12 hypertensive renal disease	http://purl.obolibrary.org/obo/MONDO_0024633	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter IV#Chapter IV Endocrine| nutritional and metabolic diseases	http://www.ebi.ac.uk/efo/EFO_0001379	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23403#NMR VLDL Cholesterol	http://www.ebi.ac.uk/efo/EFO_0008317	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block N30-N39#N30-N39 Other diseases of urinary system	http://purl.obolibrary.org/obo/HP_0000079	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22405#Anterior thigh fat-free muscle volume (left)	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C443#Malignant neoplasm: Skin of other and unspecified parts of face	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	51#Seated height	http://www.ebi.ac.uk/efo/EFO_0011011	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30250#Reticulocyte count	http://www.ebi.ac.uk/efo/EFO_0007986	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R16#Hepatomegaly and splenomegaly not elsewhere classified	http://purl.obolibrary.org/obo/HP_0002240	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C61#Malignant neoplasm of prostate	http://www.ebi.ac.uk/efo/EFO_0001663	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#Block C81-C96#C81-C96 Malignant neoplasms| stated or presumed to be primary| of lymphoid| haematopoietic and related tissue	http://purl.obolibrary.org/obo/MONDO_0002334	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I709#Generalized and unspecified atherosclerosis	http://www.ebi.ac.uk/efo/EFO_0003914	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R63#Symptoms and signs concerning food and fluid intake	http://www.ebi.ac.uk/efo/EFO_0005203	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23549#NMR Free Cholesterol in Small LDL	http://www.ebi.ac.uk/efo/EFO_0022271	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23430#NMR Concentration of HDL Particles	http://www.ebi.ac.uk/efo/EFO_0022188	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23523#NMR Concentration of IDL Particles	http://www.ebi.ac.uk/efo/EFO_0008595	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25457#Mean ISOVF in anterior limb of internal capsule on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C549#Malignant neoplasm: Corpus uteri unspecified	http://www.ebi.ac.uk/efo/EFO_0007532	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z40#Prophylactic surgery	http://www.ebi.ac.uk/efo/EFO_0009580	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20257#Inverted forced vital capacity (FVC) Z-score	http://www.ebi.ac.uk/efo/EFO_0004312	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D051#Intraductal carcinoma in situ	http://www.ebi.ac.uk/efo/EFO_0000305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C51-C58#C51-C58 Malignant neoplasms of female genital organs	http://www.ebi.ac.uk/efo/EFO_1001331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1059#malignant melanoma	http://www.ebi.ac.uk/efo/EFO_0000756	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J304#Allergic rhinitis unspecified	http://www.ebi.ac.uk/efo/EFO_0005854	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z03#Medical observation and evaluation for suspected diseases and conditions	http://www.ebi.ac.uk/efo/EFO_0009786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25445#Mean ISOVF in fornix on FA skeleton	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E11#Type 2 diabetes mellitus	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z090#Follow-up examination after surgery for other conditions	http://www.ebi.ac.uk/efo/EFO_0009517	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K449#Diaphragmatic hernia without obstruction or gangrene	http://www.ebi.ac.uk/efo/EFO_0008561	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#ChapterXVII#Chapter XVII Congenital malformations| deformations and chromosomal abnormalities	http://purl.obolibrary.org/obo/MONDO_0021147	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130837#Source of report of F00 dementia in alzheimers disease	http://purl.obolibrary.org/obo/MONDO_0001627	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Total Cholesterol to Total Lipids percentage	http://www.ebi.ac.uk/efo/EFO_0020943	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Free Cholesterol to Total Lipids in HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022234	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3627#Age angina diagnosed	http://www.ebi.ac.uk/efo/EFO_0003913	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131535#Source of report of J90 pleural effusion not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0009637	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D043#Carcinoma in situ: Skin of other and unspecified parts of face	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	2453#Cancer diagnosed by doctor	http://www.ebi.ac.uk/efo/EFO_0000311	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C920#Acute myeloblastic leukaemia [AML]	http://www.ebi.ac.uk/efo/EFO_0000222	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25807#Volume of grey matter in Middle Temporal Gyrus temporooccipital part (right)	http://www.ebi.ac.uk/efo/EFO_0005420	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131831#Source of report of L94 other localised connective tissue disorders	http://www.ebi.ac.uk/efo/EFO_1001986	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D64#Other anaemias	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G56#Mononeuropathies of upper limb	http://www.ebi.ac.uk/efo/EFO_0009558	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I340#Mitral (valve) insufficiency	http://www.ebi.ac.uk/efo/EFO_0009557	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block Q10-Q18#Q10-Q18 Congenital malformations of eye| ear| face and neck	http://www.ebi.ac.uk/efo/EFO_0000508	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8500#Duct adenocarcinoma	http://purl.obolibrary.org/obo/MONDO_0003193	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1220#diabetes	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#A28#Other zoonotic bacterial diseases not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000771	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131873#Source of report of M17 gonarthrosis arthrosis of knee	http://www.ebi.ac.uk/efo/EFO_0004616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I44#Atrioventricular and left bundle-branch block	http://www.ebi.ac.uk/efo/EFO_0004138	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23616#NMR Cholesteryl Esters to Total Lipids in Large LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022249	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C180#Malignant neoplasm: Caecum	http://purl.obolibrary.org/obo/MONDO_0002033	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132037#Source of report of N20 calculus of kidney and ureter	http://www.ebi.ac.uk/efo/EFO_0004253	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K802#Calculus of gallbladder without cholecystitis	http://www.ebi.ac.uk/efo/EFO_0004799	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q780#Osteogenesis imperfecta	http://www.orpha.net/ORDO/Orphanet_666	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#9989#Myelodysplastic syndrome NOS	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#H40#Glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I269#Pulmonary embolism without mention of acute cor pulmonale	http://www.ebi.ac.uk/efo/EFO_0003827	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block J80-J84#J80-J84 Other respiratory diseases principally affecting the interstitium	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C570#Malignant neoplasm: Fallopian tube	http://purl.obolibrary.org/obo/MONDO_0002158	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K914#Colostomy and enterostomy malfunction	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I80#Phlebitis and thrombophlebitis	http://www.ebi.ac.uk/efo/EFO_0003907	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block H40-H42#H40-H42 Glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D151#Benign neoplasm: Heart	http://purl.obolibrary.org/obo/MONDO_0021450	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z511#Chemotherapy session for neoplasm	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23614#NMR Phospholipids to Total Lipids in Large LDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25889#Volume of grey matter in Amygdala (right)	http://www.ebi.ac.uk/efo/EFO_0005420	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23564#NMR Triglycerides in Large HDL	http://www.ebi.ac.uk/efo/EFO_0022318	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23414#NMR Phospholipids in HDL	http://www.ebi.ac.uk/efo/EFO_0022293	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E669#Obesity unspecified	http://www.ebi.ac.uk/efo/EFO_0001073	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N39#Other disorders of urinary system	http://www.ebi.ac.uk/efo/EFO_0009690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Free Cholesterol to Cholesteryl Esters in Large HDL ratio	http://www.ebi.ac.uk/efo/EFO_0022257	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30000#White blood cell (leukocyte) count	http://www.ebi.ac.uk/efo/EFO_0004308	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C541#Malignant neoplasm: Endometrium	http://purl.obolibrary.org/obo/MONDO_0011962	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131309#Source of report of I26 pulmonary embolism	http://www.ebi.ac.uk/efo/EFO_0003827	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25439#Mean OD in tapetum on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H401#Primary open-angle glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G98#Other disorders of nervous system not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I802#Phlebitis and thrombophlebitis of other deep vessels of lower extremities	http://purl.obolibrary.org/obo/HP_0004418	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E03#Other hypothyroidism	http://www.ebi.ac.uk/efo/EFO_0004705	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block H90-H95#H90-H95 Other disorders of ear	http://www.ebi.ac.uk/efo/EFO_0009668	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1065#hypertension	http://www.ebi.ac.uk/efo/EFO_0000537	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23469#NMR Tyrosine	http://www.ebi.ac.uk/efo/EFO_0005058	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131023#Source of report of G20 parkinsons disease	http://purl.obolibrary.org/obo/MONDO_0005180	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23525#NMR Phospholipids in IDL	http://www.ebi.ac.uk/efo/EFO_0022164	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block R00-R09#R00-R09 Symptoms and signs involving the circulatory and respiratory systems	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block R00-R09#R00-R09 Symptoms and signs involving the circulatory and respiratory systems	http://www.ebi.ac.uk/efo/EFO_0000319	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23566#NMR Total Lipids in Medium HDL	http://www.ebi.ac.uk/efo/EFO_0022310	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C509#Malignant neoplasm: Breast unspecified	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131167#Source of report of H26 other cataract	http://purl.obolibrary.org/obo/MONDO_0005129	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23234#Spine BMD (bone mineral density)	http://www.ebi.ac.uk/efo/EFO_0007701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131795#Source of report of L72 follicular cysts of skin and subcutaneous tissue	http://www.ebi.ac.uk/efo/EFO_1001329	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N185#Chronic kidney disease stage 5	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K768#Other specified diseases of liver	http://www.ebi.ac.uk/efo/EFO_0001421	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I780#Hereditary haemorrhagic telangiectasia	http://www.orpha.net/ORDO/Orphanet_774	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N180#N180 End-stage renal disease	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1473#high cholesterol	http://purl.obolibrary.org/obo/HP_0003124	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1615#obsessive compulsive disorder (ocd)	http://www.ebi.ac.uk/efo/EFO_0004242	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23329#Femur shaft bone area (left)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23604#NMR Phospholipids to Total Lipids in Very Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C795#Secondary malignant neoplasm of bone and bone marrow	http://purl.obolibrary.org/obo/MONDO_0005374	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I12#Hypertensive renal disease	http://purl.obolibrary.org/obo/MONDO_0024633	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#J84#Other interstitial pulmonary diseases	http://www.ebi.ac.uk/efo/EFO_0004244	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block Z00-Z13#Z00-Z13 Persons encountering health services for examination and investigation	http://www.ebi.ac.uk/efo/EFO_0009786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23461#NMR Glutamine	http://www.ebi.ac.uk/efo/EFO_0009768	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesteryl Esters to Cholesterol in Very Small VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022259	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C436#Malignant neoplasm: Malignant melanoma of upper limb including shoulder	http://purl.obolibrary.org/obo/MONDO_0002898	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23551#NMR Concentration of Very Large HDL Particles	http://www.ebi.ac.uk/efo/EFO_0022188	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5084#Spherical power (right)	http://www.ebi.ac.uk/efo/EFO_0004731	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5923#Age macular degeneration diagnosed	http://www.ebi.ac.uk/efo/EFO_0001365	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C795#Secondary malignant neoplasm of bone and bone marrow	http://purl.obolibrary.org/obo/MONDO_0005374	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block I20-I25#I20-I25 Ischaemic heart diseases	http://www.ebi.ac.uk/efo/EFO_0003777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z492#Other dialysis	http://www.ebi.ac.uk/efo/EFO_1002048	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	120011#Ever had gout	http://www.ebi.ac.uk/efo/EFO_0004274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30600#Albumin	http://www.ebi.ac.uk/efo/EFO_0004535	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23481#NMR Concentration of Chylomicrons and Extremely Large VLDL Particles	http://www.ebi.ac.uk/efo/EFO_0022260	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25109#Mean MD in fornix on FA skeleton	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K509#Crohn disease unspecified	http://www.ebi.ac.uk/efo/EFO_0000384	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I23#Certain current complications following acute myocardial infarction	http://www.ebi.ac.uk/efo/EFO_0008583	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N28#Other disorders of kidney and ureter not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0009690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block N25-N29#N25-N29 Other disorders of kidney and ureter	http://www.ebi.ac.uk/efo/EFO_0009690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block D65-D69#D65-D69 Coagulation defects| purpura and other haemorrhagic conditions	http://purl.obolibrary.org/obo/MONDO_0002243	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1030#eye and|or adnexal cancer	http://www.ebi.ac.uk/efo/EFO_0003824	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z513#Blood transfusion (without reported diagnosis)	http://www.ebi.ac.uk/efo/EFO_0020988	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C19#Malignant neoplasm of rectosigmoid junction	http://purl.obolibrary.org/obo/MONDO_0002425	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20153#Forced expiratory volume in 1-second (FEV1) predicted	http://www.ebi.ac.uk/efo/EFO_0004314	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block Q65-Q79#Q65-Q79 Congenital malformations and deformations of the musculoskeletal system	http://www.ebi.ac.uk/efo/EFO_0009676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#F03#Unspecified dementia	http://purl.obolibrary.org/obo/MONDO_0001627	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131375#Source of report of I67 other cerebrovascular diseases	http://www.ebi.ac.uk/efo/EFO_0003763	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D447#Neoplasm of uncertain or unknown behaviour: Aortic body and other paraganglia	http://www.ebi.ac.uk/efo/EFO_1000453	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C30-C39#C30-C39 Malignant neoplasms of respiratory and intrathoracic organs	http://purl.obolibrary.org/obo/MONDO_0000376	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30760#HDL cholesterol	http://www.ebi.ac.uk/efo/EFO_0004612	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23104#Body mass index (BMI)	http://www.ebi.ac.uk/efo/EFO_0004340	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K900#Coeliac disease	http://www.ebi.ac.uk/efo/EFO_0001060	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D471#Chronic myeloproliferative disease	http://www.ebi.ac.uk/efo/EFO_0002428	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block R50-R69#R50-R69 General symptoms and signs	http://www.ebi.ac.uk/efo/EFO_0003765	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D64#Other anaemias	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23459#NMR Omega-6 Fatty Acids to Omega-3 Fatty Acids ratio	http://www.ebi.ac.uk/efo/EFO_0010732	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C772#Secondary and unspecified malignant neoplasm: Intra-abdominal lymph nodes	http://www.ebi.ac.uk/efo/EFO_0004906	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30260#Mean reticulocyte volume	http://www.ebi.ac.uk/efo/EFO_0010701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130723#Source of report of E21 hyperparathyroidism and other disorders of parathyroid gland	http://www.ebi.ac.uk/efo/EFO_0008506	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I420#Dilated cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L82#Seborrhoeic keratosis	http://www.ebi.ac.uk/efo/EFO_0005584	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C94#Other leukaemias of specified cell type	http://www.ebi.ac.uk/efo/EFO_0000565	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q25#Congenital malformations of great arteries	http://www.orpha.net/ORDO/Orphanet_98724	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1002#breast cancer	http://www.ebi.ac.uk/efo/EFO_0000305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23477#NMR Acetone	http://www.ebi.ac.uk/efo/EFO_0010989	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23122#Arm predicted mass (right)	http://www.ebi.ac.uk/efo/EFO_0004302	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E116#Type 2 diabetes mellitus; With other specified complications	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z850#Personal history of malignant neoplasm of digestive organs	http://www.ebi.ac.uk/efo/EFO_1000218	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D37#Neoplasm of uncertain or unknown behaviour of oral cavity and digestive organs	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	6152#8#Asthma	http://purl.obolibrary.org/obo/MONDO_0004979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23516#NMR Concentration of Very Small VLDL Particles	http://www.ebi.ac.uk/efo/EFO_0022151	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K90#Intestinal malabsorption	http://www.ebi.ac.uk/efo/EFO_0009554	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I500#Congestive heart failure	http://www.ebi.ac.uk/efo/EFO_0000373	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1427#polycystic kidney	http://www.ebi.ac.uk/efo/EFO_0008620	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1126#spontaneous pneumothorax|recurrent pneumothorax	http://purl.obolibrary.org/obo/HP_0002108	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23446#NMR Polyunsaturated Fatty Acids	http://www.ebi.ac.uk/efo/EFO_0010733	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H579#Disorder of eye and adnexa unspecified	http://www.ebi.ac.uk/efo/EFO_0009546	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23553#NMR Phospholipids in Very Large HDL	http://www.ebi.ac.uk/efo/EFO_0022298	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I47#Paroxysmal tachycardia	http://www.ebi.ac.uk/efo/EFO_0009493	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25119#Mean MD in cerebral peduncle on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q273#Peripheral arteriovenous malformation	http://purl.obolibrary.org/obo/MONDO_0001256	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#D47#Other neoplasms of uncertain or unknown behaviour of lymphoid haematopoietic and related tissue	http://www.ebi.ac.uk/efo/EFO_0001642	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block D55-D59#D55-D59 Haemolytic anaemias	http://www.ebi.ac.uk/efo/EFO_0005558	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Q61#Cystic kidney disease	http://www.ebi.ac.uk/efo/EFO_0008615	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20001#1055#chronic lymphocytic	http://www.ebi.ac.uk/efo/EFO_0000095	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1068#venous thromboembolic disease	http://www.ebi.ac.uk/efo/EFO_0004286	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23210#Femur shaft BMD (bone mineral density) (right)	http://www.ebi.ac.uk/efo/EFO_0007620	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block K40-K46#K40-K46 Hernia	http://purl.obolibrary.org/obo/HP_0100790	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z806#Family history of leukaemia	http://www.ebi.ac.uk/efo/EFO_0000565	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5135#3mm strong meridian (left)	http://www.ebi.ac.uk/efo/EFO_0004731	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E14#Unspecified diabetes mellitus	http://www.ebi.ac.uk/efo/EFO_0000400	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#L721#Trichilemmal cyst	http://www.ebi.ac.uk/efo/EFO_1001329	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R10#Abdominal and pelvic pain	http://purl.obolibrary.org/obo/HP_0002027	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D151#Benign neoplasm: Heart	http://purl.obolibrary.org/obo/MONDO_0021450	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z858#Personal history of malignant neoplasms of other organs and systems	http://purl.obolibrary.org/obo/MONDO_0004992	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23531#NMR Total Lipids in Large LDL	http://www.ebi.ac.uk/efo/EFO_0022163	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23127#Trunk fat percentage	http://www.ebi.ac.uk/efo/EFO_0004324	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4120#Heel broadband ultrasound attenuation (right)	http://www.ebi.ac.uk/efo/EFO_0004514	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I34#Nonrheumatic mitral valve disorders	http://www.ebi.ac.uk/efo/EFO_0009557	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M23#Internal derangement of knee	http://www.ebi.ac.uk/efo/EFO_0009507	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block E00-E07#E00-E07 Disorders of thyroid gland	http://www.ebi.ac.uk/efo/EFO_1000627	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D46#Myelodysplastic syndromes	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23463#NMR Histidine	http://www.ebi.ac.uk/efo/EFO_0009769	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block G30-G32#G30-G32 Other degenerative diseases of the nervous system	http://www.ebi.ac.uk/efo/EFO_0005772	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N03#Chronic nephritic syndrome	http://www.ebi.ac.uk/efo/EFO_0004255	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L98#Other disorders of skin and subcutaneous tissue not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23114#Leg predicted mass (right)	http://www.ebi.ac.uk/efo/EFO_0004302	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C184#Malignant neoplasm: Transverse colon	http://www.ebi.ac.uk/efo/EFO_0004288	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter XVIII#Chapter XVIII Symptoms| signs and abnormal clinical and laboratory findings| not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0003765	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C44#Other malignant neoplasms of skin	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H36#Retinal disorders in diseases classified elsewhere	http://www.ebi.ac.uk/efo/EFO_0003839	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D126#Benign neoplasm: Colon unspecified	http://purl.obolibrary.org/obo/MONDO_0021444	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23520#NMR Cholesteryl Esters in Very Small VLDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130829#Source of report of E87 other disorders of fluid electrolyte and acid base balance	http://purl.obolibrary.org/obo/HP_0001939	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block L80-L99#L80-L99 Other disorders of the skin and subcutaneous tissue	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131125#Source of report of G98 other disorders of nervous system not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K63#Other diseases of intestine	http://www.ebi.ac.uk/efo/EFO_0009431	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J459#Asthma unspecified	http://purl.obolibrary.org/obo/MONDO_0004979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D469#Myelodysplastic syndrome unspecified	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D44#Neoplasm of uncertain or unknown behaviour of endocrine glands	http://www.ebi.ac.uk/efo/EFO_0003769	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M790#Rheumatism unspecified	http://www.ebi.ac.uk/efo/EFO_0005755	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K25#Gastric ulcer	http://www.ebi.ac.uk/efo/EFO_0009454	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131187#Source of report of H40 glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#G82#Paraplegia and tetraplegia	http://www.ebi.ac.uk/efo/EFO_0009684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D46#Myelodysplastic syndromes	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Total Phospholipids to Total Lipids percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25887#Volume of grey matter in Hippocampus (right)	http://www.ebi.ac.uk/efo/EFO_0005420	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23572#NMR Concentration of Small HDL Particles	http://www.ebi.ac.uk/efo/EFO_0022188	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M819#Osteoporosis unspecified	http://www.ebi.ac.uk/efo/EFO_0003882	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30830#SHBG	http://www.ebi.ac.uk/efo/EFO_0004696	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#9983#Refractory anemia with excess blasts	http://www.ebi.ac.uk/efo/EFO_0003811	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130623#Source of report of D50 iron deficiency anaemia	http://purl.obolibrary.org/obo/HP_0001891	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z121#Special screening examination for neoplasm of intestinal tract	http://www.ebi.ac.uk/efo/EFO_0021523	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K82#Other diseases of gallbladder	http://www.ebi.ac.uk/efo/EFO_0003832	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R29#Other symptoms and signs involving the nervous and musculoskeletal systems	http://purl.obolibrary.org/obo/HP_0000924	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block N20-N23#N20-N23 Urolithiasis	http://purl.obolibrary.org/obo/MONDO_0024647	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#G06#Intracranial and intraspinal abscess and granuloma	http://www.ebi.ac.uk/efo/EFO_0009462	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1456#malabsorption|coeliac disease	http://www.ebi.ac.uk/efo/EFO_0001060	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23503#NMR Total Lipids in Medium VLDL	http://www.ebi.ac.uk/efo/EFO_0022153	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D36#Benign neoplasm of other and unspecified sites	http://www.ebi.ac.uk/efo/EFO_0002422	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C43-C44#C43-C44 Melanoma and other malignant neoplasms of skin	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H913#Deaf mutism not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0001063	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M480#Spinal stenosis	http://www.ebi.ac.uk/efo/EFO_0007490	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Free Cholesterol to Total Lipids in LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022283	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23574#NMR Phospholipids in Small HDL	http://www.ebi.ac.uk/efo/EFO_0022296	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C570#Malignant neoplasm: Fallopian tube	http://purl.obolibrary.org/obo/MONDO_0002158	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130633#Source of report of D56 thalassaemia	http://www.ebi.ac.uk/efo/EFO_1001996	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q44#Congenital malformations of gallbladder bile ducts and liver	http://purl.obolibrary.org/obo/HP_0001392	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I34#Nonrheumatic mitral valve disorders	http://www.ebi.ac.uk/efo/EFO_0009557	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23552#NMR Total Lipids in Very Large HDL	http://www.ebi.ac.uk/efo/EFO_0022312	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20161#Pack years of smoking	http://www.ebi.ac.uk/efo/EFO_0005671	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23331#Femur shaft BMC (bone mineral content) (left)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H90#Conductive and sensorineural hearing loss	http://www.ebi.ac.uk/efo/EFO_1001176	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H269#Cataract unspecified	http://purl.obolibrary.org/obo/MONDO_0005129	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block L40-L45#L40-L45 Papulosquamous disorders	http://www.ebi.ac.uk/efo/EFO_1000636	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block C76-C80#C76-C80 Malignant neoplasms of ill-defined| secondary and unspecified sites	http://www.ebi.ac.uk/efo/EFO_1001175	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E66#Obesity	http://www.ebi.ac.uk/efo/EFO_0001073	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K317#Polyp of stomach and duodenum	http://www.ebi.ac.uk/efo/EFO_0009608	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I25#Chronic ischaemic heart disease	http://www.ebi.ac.uk/efo/EFO_0001645	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D469#Myelodysplastic syndrome unspecified	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#O244#Diabetes mellitus arising in pregnancy	http://www.ebi.ac.uk/efo/EFO_0004593	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23571#NMR Triglycerides in Medium HDL	http://www.ebi.ac.uk/efo/EFO_0022321	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D126#Benign neoplasm: Colon unspecified	http://purl.obolibrary.org/obo/MONDO_0002278	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	22404#Posterior thigh fat-free muscle volume (right)	http://www.ebi.ac.uk/efo/EFO_0005106	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N18#Chronic kidney disease	http://www.ebi.ac.uk/efo/EFO_0003884	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C435#Malignant neoplasm: Malignant melanoma of trunk	http://purl.obolibrary.org/obo/MONDO_0021350	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I47#Paroxysmal tachycardia	http://www.ebi.ac.uk/efo/EFO_0009493	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23573#NMR Total Lipids in Small HDL	http://www.ebi.ac.uk/efo/EFO_0022311	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E835#Disorders of calcium metabolism	http://www.ebi.ac.uk/efo/EFO_0005769	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D051#Intraductal carcinoma in situ	http://www.ebi.ac.uk/efo/EFO_0000305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131383#Source of report of I71 aortic aneurysm and dissection	http://www.ebi.ac.uk/efo/EFO_0001666	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131743#Source of report of L40 psoriasis	http://www.ebi.ac.uk/efo/EFO_0000676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	3144#Heel Broadband ultrasound attenuation direct entry	http://www.ebi.ac.uk/efo/EFO_0004514	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#L70#Acne	http://www.ebi.ac.uk/efo/EFO_0003894	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C446#Malignant neoplasm: Skin of upper limb including shoulder	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	21001#Body mass index (BMI)	http://www.ebi.ac.uk/efo/EFO_0004340	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30640#Apolipoprotein B	http://www.ebi.ac.uk/efo/EFO_0004615	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N20#Calculus of kidney and ureter	http://www.ebi.ac.uk/efo/EFO_0004253	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M81#Osteoporosis without pathological fracture	http://www.ebi.ac.uk/efo/EFO_0003882	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D69#Purpura and other haemorrhagic conditions	http://purl.obolibrary.org/obo/HP_0000979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#Block C76-C80#C76-C80 Malignant neoplasms of ill-defined| secondary and unspecified sites	http://www.ebi.ac.uk/efo/EFO_1001175	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23646#NMR Cholesteryl Esters to Total Lipids in Small HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23433#NMR Average Diameter for HDL Particles	http://www.ebi.ac.uk/efo/EFO_0008592	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23575#NMR Cholesterol in Small HDL	http://www.ebi.ac.uk/efo/EFO_0022226	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23596#NMR Cholesteryl Esters to Total Lipids in Medium VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022253	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D759#Disease of blood and blood-forming organs unspecified	http://www.ebi.ac.uk/efo/EFO_0005803	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J450#Predominantly allergic asthma	http://purl.obolibrary.org/obo/MONDO_0004784	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C505#Malignant neoplasm: Lower-outer quadrant of breast	http://purl.obolibrary.org/obo/MONDO_0007254	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C927#Other myeloid leukaemia	http://purl.obolibrary.org/obo/MONDO_0004643	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20258#Inverted FEV1/ FVC ratio Z-score	http://www.ebi.ac.uk/efo/EFO_0004713	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D462#Refractory anaemia with excess of blasts [RAEB]	http://www.ebi.ac.uk/efo/EFO_0003811	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23448#NMR Saturated Fatty Acids	http://www.ebi.ac.uk/efo/EFO_0022304	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#M169#Coxarthrosis unspecified	http://www.ebi.ac.uk/efo/EFO_1000786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23405#NMR LDL Cholesterol	http://www.ebi.ac.uk/efo/EFO_0004611	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130047#Source of report of A28 other zoonotic bacterial diseases not elsewhere classified	http://www.ebi.ac.uk/efo/EFO_0000771	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	NMR Cholesterol to Total Lipids in HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022237	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23118#Leg predicted mass (left)	http://www.ebi.ac.uk/efo/EFO_0004302	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30220#Basophill percentage	http://www.ebi.ac.uk/efo/EFO_0007992	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D649#Anaemia unspecified	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#D05#Carcinoma in situ of breast	http://www.ebi.ac.uk/efo/EFO_0000305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K914#Colostomy and enterostomy malfunction	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#C91#Lymphoid leukaemia	http://www.ebi.ac.uk/efo/EFO_0004289	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterX#Chapter X Diseases of the respiratory system	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4041#Gestational diabetes only	http://www.ebi.ac.uk/efo/EFO_0004593	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block B35-B49#B35-B49 Mycoses	http://purl.obolibrary.org/obo/MONDO_0002041	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23419#NMR Total Free Cholesterol	http://www.ebi.ac.uk/efo/EFO_0008591	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23642#NMR Free Cholesterol to Total Lipids in Medium HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022237	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block K90-K93#K90-K93 Other diseases of the digestive system	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131627#Source of report of K50 crohns disease regional enteritis	http://www.ebi.ac.uk/efo/EFO_0000384	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I71#Aortic aneurysm and dissection	http://www.ebi.ac.uk/efo/EFO_0001666	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1142#gastric|stomach ulcers	http://www.ebi.ac.uk/efo/EFO_0009454	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23004#EBNA-1 antigen for Epstein-Barr Virus	http://www.ebi.ac.uk/efo/EFO_0009271	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter XII#Chapter XII Diseases of the skin and subcutaneous tissue	http://www.ebi.ac.uk/efo/EFO_0000701	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23274#Legs fat mass	http://www.ebi.ac.uk/efo/EFO_0005409	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23609#NMR Phospholipids to Total Lipids in IDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23099#Body fat percentage	http://www.ebi.ac.uk/efo/EFO_0007800	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23105#Basal metabolic rate	http://www.ebi.ac.uk/efo/EFO_0007777	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25002#Volume of peripheral cortical grey matter	http://www.ebi.ac.uk/efo/EFO_0005420	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block L20-L30#L20-L30 Dermatitis and eczema	http://purl.obolibrary.org/obo/HP_0000964	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block K20-K31#K20-K31 Diseases of oesophagus| stomach and duodenum	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D361#Benign neoplasm: Peripheral nerves and autonomic nervous system	http://purl.obolibrary.org/obo/MONDO_0002366	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30500#Microalbumin in urine	http://www.ebi.ac.uk/efo/EFO_0010967	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C186#Malignant neoplasm: Descending colon	http://www.ebi.ac.uk/efo/EFO_1001950	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131859#Source of report of M10 gout	http://www.ebi.ac.uk/efo/EFO_0004274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#N25#Disorders resulting from impaired renal tubular function	http://www.ebi.ac.uk/efo/EFO_0009566	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R59#Enlarged lymph nodes	http://purl.obolibrary.org/obo/HP_0002716	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C43#Malignant melanoma of skin	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30010#Red blood cell (erythrocyte) count	http://www.ebi.ac.uk/efo/EFO_0004305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131807#Source of report of L82 seborrhoeic keratosis	http://www.ebi.ac.uk/efo/EFO_0005584	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23125#Arm fat-free mass (left)	http://www.ebi.ac.uk/efo/EFO_0004995	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23318#Legs combined bone area	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#J931#Other spontaneous pneumothorax	http://purl.obolibrary.org/obo/MONDO_0002076	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25247#Mean L1 in tapetum on FA skeleton (left)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C786#Secondary malignant neoplasm of retroperitoneum and peritoneum	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#E213#Hyperparathyroidism unspecified	http://www.ebi.ac.uk/efo/EFO_0008506	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K31#Other diseases of stomach and duodenum	http://www.ebi.ac.uk/efo/EFO_0000405	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I780#Hereditary haemorrhagic telangiectasia	http://www.orpha.net/ORDO/Orphanet_774	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40001#C25#Malignant neoplasm of pancreas	http://www.ebi.ac.uk/efo/EFO_0002618	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#H019#Inflammation of eyelid unspecified	http://www.ebi.ac.uk/efo/EFO_0009536	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	50#Standing height	http://www.ebi.ac.uk/efo/EFO_0004339	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q77#Osteochondrodysplasia with defects of growth of tubular bones and spine	http://www.ebi.ac.uk/efo/EFO_0005571	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23528#NMR Free Cholesterol in IDL	http://www.ebi.ac.uk/efo/EFO_0022181	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20015#Sitting height	http://www.ebi.ac.uk/efo/EFO_0011011	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C911#Chronic lymphocytic leukaemia of B-cell type	http://www.ebi.ac.uk/efo/EFO_0000095	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H26#Other cataract	http://purl.obolibrary.org/obo/MONDO_0005129	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterIV#Chapter IV Endocrine| nutritional and metabolic diseases	http://www.ebi.ac.uk/efo/EFO_0001379	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D36#Benign neoplasm of other and unspecified sites	http://www.ebi.ac.uk/efo/EFO_0002422	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#H271#Dislocation of lens	http://www.ebi.ac.uk/efo/EFO_0009674	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D474#Osteomyelofibrosis	http://www.ebi.ac.uk/efo/EFO_0002430	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Z40#Prophylactic surgery	http://www.ebi.ac.uk/efo/EFO_0009580	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Z00-Z13#Z00-Z13 Persons encountering health services for examination and investigation	http://www.ebi.ac.uk/efo/EFO_0009786	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K62#Other diseases of anus and rectum	http://www.ebi.ac.uk/efo/EFO_0009685	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1242#eye|eyelid problem	http://www.ebi.ac.uk/efo/EFO_0003966	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	132073#Source of report of N40 hyperplasia of prostate	http://www.ebi.ac.uk/efo/EFO_0009602	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23456#NMR Linoleic Acid to Total Fatty Acids percentage	http://www.ebi.ac.uk/efo/EFO_0022303	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	21002#Weight	http://www.ebi.ac.uk/efo/EFO_0004338	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30850#Testosterone	http://www.ebi.ac.uk/efo/EFO_0004908	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30870#Triglycerides	http://www.ebi.ac.uk/efo/EFO_0020947	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23316#Leg bone area (right)	http://www.ebi.ac.uk/efo/EFO_0004512	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D04#Carcinoma in situ of skin	http://www.ebi.ac.uk/efo/EFO_0004198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C61#Malignant neoplasm of prostate	http://www.ebi.ac.uk/efo/EFO_0001663	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D46#Myelodysplastic syndromes	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1111#asthma	http://purl.obolibrary.org/obo/MONDO_0004979	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23436#NMR Total Cholines	http://www.ebi.ac.uk/efo/EFO_0010116	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30700#Creatinine	http://www.ebi.ac.uk/efo/EFO_0004518	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23526#NMR Cholesterol in IDL	http://www.ebi.ac.uk/efo/EFO_0021899	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4080#Systolic blood pressure automated reading	http://www.ebi.ac.uk/efo/EFO_0006335	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#M329#Systemic lupus erythematosus unspecified	http://www.ebi.ac.uk/efo/EFO_0002690	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8380#Endometrioid carcinoma	http://www.ebi.ac.uk/efo/EFO_0000466	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23527#NMR Cholesteryl Esters in IDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23620#NMR Cholesterol to Total Lipids in Medium LDL percentage	http://www.ebi.ac.uk/efo/EFO_0022238	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23507#NMR Free Cholesterol in Medium VLDL	http://www.ebi.ac.uk/efo/EFO_0008317	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5097#6mm weak meridian (left)	http://www.ebi.ac.uk/efo/EFO_0004731	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E34#Other endocrine disorders	http://www.ebi.ac.uk/efo/EFO_0001379	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Q61#Cystic kidney disease	http://www.ebi.ac.uk/efo/EFO_0008615	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D70#Agranulocytosis	http://purl.obolibrary.org/obo/HP_0012234	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I80#Phlebitis and thrombophlebitis	http://www.ebi.ac.uk/efo/EFO_0003907	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R065#Mouth breathing	http://purl.obolibrary.org/obo/OMIT_0010101	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23478#NMR Creatinine	http://www.ebi.ac.uk/efo/EFO_0004518	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C833#Diffuse large B-cell lymphoma	http://www.ebi.ac.uk/efo/EFO_0000403	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D43#Neoplasm of uncertain or unknown behaviour of brain and central nervous system	http://www.ebi.ac.uk/efo/EFO_0000326	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23335#Femur total BMC (bone mineral content) (left)	http://www.ebi.ac.uk/efo/EFO_0007621	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K628#Other specified diseases of anus and rectum	http://www.ebi.ac.uk/efo/EFO_0009685	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E213#Hyperparathyroidism unspecified	http://www.ebi.ac.uk/efo/EFO_0008506	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#N870#Mild cervical dysplasia	http://www.ebi.ac.uk/efo/EFO_1000910	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K259#Gastric ulcer; Unspecified as acute or chronic without haemorrhage or perforation	http://www.ebi.ac.uk/efo/EFO_0009454	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C45-C49#C45-C49 Malignant neoplasms of mesothelial and soft tissue	http://www.ebi.ac.uk/efo/EFO_1000355	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C184#Malignant neoplasm: Transverse colon	http://purl.obolibrary.org/obo/MONDO_0021063	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23107#Impedance of leg (right)	http://purl.obolibrary.org/obo/HP_0000924	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C437#Malignant neoplasm: Malignant melanoma of lower limb including hip	http://www.ebi.ac.uk/efo/EFO_0000389	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#F17#Mental and behavioural disorders due to use of tobacco	http://www.ebi.ac.uk/efo/EFO_0003768	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23467#NMR Valine	http://www.ebi.ac.uk/efo/EFO_0009792	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D120#Benign neoplasm: Caecum	http://purl.obolibrary.org/obo/MONDO_0021464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23499#NMR Cholesteryl Esters in Large VLDL	http://www.ebi.ac.uk/efo/EFO_0010351	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131885#Source of report of M23 internal derangement of knee	http://www.ebi.ac.uk/efo/EFO_0009507	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25408#Mean OD in anterior limb of internal capsule on FA skeleton (right)	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40002#C92#Myeloid leukaemia	http://purl.obolibrary.org/obo/MONDO_0004643	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block D55-D59#D55-D59 Haemolytic anaemias	http://www.ebi.ac.uk/efo/EFO_0005558	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#ChapterXIV#Chapter XIV Diseases of the genitourinary system	http://www.ebi.ac.uk/efo/EFO_0009663	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23418#NMR Cholesteryl Esters in HDL	http://www.ebi.ac.uk/efo/EFO_0022159	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5254#Intra-ocular pressure corneal-compensated (right)	http://www.ebi.ac.uk/efo/EFO_0004695	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25301#Mean L3 in fornix on FA skeleton	http://www.ebi.ac.uk/efo/EFO_0004464	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R161#Splenomegaly not elsewhere classified	http://purl.obolibrary.org/obo/HP_0001744	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D05#Carcinoma in situ of breast	http://www.ebi.ac.uk/efo/EFO_0000305	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block Q60-Q64#Q60-Q64 Congenital malformations of the urinary system	http://purl.obolibrary.org/obo/HP_0000079	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#Block D37-D48#D37-D48 Neoplasms of uncertain or unknown behaviour	http://www.ebi.ac.uk/efo/EFO_0000616	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	4022#Age pulmonary embolism (blood clot in lung) diagnosed	http://www.ebi.ac.uk/efo/EFO_0003827	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23561#NMR Cholesterol in Large HDL	http://www.ebi.ac.uk/efo/EFO_0021900	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D131#Benign neoplasm: Stomach	http://purl.obolibrary.org/obo/MONDO_0021449	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23497#NMR Phospholipids in Large VLDL	http://www.ebi.ac.uk/efo/EFO_0022169	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131323#Source of report of I34 nonrheumatic mitral valve disorders	http://www.ebi.ac.uk/efo/EFO_0009557	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131005#Source of report of G06 intracranial and intraspinal abscess and granuloma	http://www.ebi.ac.uk/efo/EFO_1001395	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D469#Myelodysplastic syndrome unspecified	http://www.ebi.ac.uk/efo/EFO_0000198	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R040#Epistaxis	http://www.ebi.ac.uk/efo/EFO_0003895	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block N20-N23#N20-N23 Urolithiasis	http://purl.obolibrary.org/obo/MONDO_0024647	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#8140#Adenocarcinoma NOS	http://www.ebi.ac.uk/efo/EFO_0000228	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40006#Block C51-C58#C51-C58 Malignant neoplasms of female genital organs	http://www.ebi.ac.uk/efo/EFO_1001331	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20002#1466#gout	http://www.ebi.ac.uk/efo/EFO_0004274	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	40011#9540#Malignant peripheral nerve sheath tumor	http://www.ebi.ac.uk/efo/EFO_0000760	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23644#NMR Phospholipids to Total Lipids in Small HDL percentage	http://www.ebi.ac.uk/efo/EFO_0020946	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter XIII#Chapter XIII Diseases of the musculoskeletal system and connective tissue	http://www.ebi.ac.uk/efo/EFO_0009676	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	5901#Age when diabetes-related eye disease diagnosed	http://www.ebi.ac.uk/efo/EFO_0009486	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25890#Volume of grey matter in Ventral Striatum (left)	http://www.ebi.ac.uk/efo/EFO_0005420	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	131629#Source of report of K51 ulcerative colitis	http://www.ebi.ac.uk/efo/EFO_0000729	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#C785#Secondary malignant neoplasm of large intestine and rectum	http://www.ebi.ac.uk/efo/EFO_0009812	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D12#Benign neoplasm of colon rectum anus and anal canal	http://www.ebi.ac.uk/efo/EFO_0003835	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block K70-K77#K70-K77 Diseases of liver	http://www.ebi.ac.uk/efo/EFO_0001421	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23630#NMR Cholesterol to Total Lipids in Very Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022243	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23633#NMR Triglycerides to Total Lipids in Very Large HDL percentage	http://www.ebi.ac.uk/efo/EFO_0022339	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I252#Old myocardial infarction	http://www.ebi.ac.uk/efo/EFO_0000612	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#D44#Neoplasm of uncertain or unknown behaviour of endocrine glands	http://www.ebi.ac.uk/efo/EFO_0003769	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R04#Haemorrhage from respiratory passages	http://purl.obolibrary.org/obo/MP_0001914	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Block K80-K87#K80-K87 Disorders of gallbladder| biliary tract and pancreas	http://www.ebi.ac.uk/efo/EFO_0003832	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C18#Malignant neoplasm of colon	http://www.ebi.ac.uk/efo/EFO_1001950	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C20#Malignant neoplasm of rectum	http://www.ebi.ac.uk/efo/EFO_1000657	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23598#NMR Triglycerides to Total Lipids in Medium VLDL percentage	http://www.ebi.ac.uk/efo/EFO_0022335	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Z080#Follow-up examination after surgery for malignant neoplasm	http://www.ebi.ac.uk/efo/EFO_0004542	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#K635#Polyp of colon	http://www.ebi.ac.uk/efo/EFO_1000184	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25000#Volumetric scaling from T1 head image to standard space	http://www.ebi.ac.uk/efo/EFO_0006930	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I120#Hypertensive renal disease with renal failure	http://purl.obolibrary.org/obo/MONDO_0024633	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D13#Benign neoplasm of other and ill-defined parts of digestive system	http://www.ebi.ac.uk/efo/EFO_0008549	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#R94#Abnormal results of function studies	http://www.ebi.ac.uk/efo/EFO_0009628	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#D61#Other aplastic anaemias	http://purl.obolibrary.org/obo/HP_0001915	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#I28#Other diseases of pulmonary vessels	http://www.ebi.ac.uk/efo/EFO_0000684	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	20256#Inverted forced expiratory volume in 1-second (FEV1) Z-score	http://www.ebi.ac.uk/efo/EFO_0004314	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	130649#Source of report of D64 other anaemias	http://purl.obolibrary.org/obo/MONDO_0002280	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I259#Chronic ischaemic heart disease unspecified	http://www.ebi.ac.uk/efo/EFO_0001645	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#I509#Heart failure unspecified	http://www.ebi.ac.uk/efo/EFO_0003144	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#E87#Other disorders of fluid electrolyte and acid-base balance	http://purl.obolibrary.org/obo/HP_0001939	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#Chapter VIII#Chapter VIII Diseases of the ear and mastoid process	http://www.ebi.ac.uk/efo/EFO_1001455	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#Block C76-C80#C76-C80 Malignant neoplasms of ill-defined| secondary and unspecified sites	http://www.ebi.ac.uk/efo/EFO_1001175	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	union#B35#Dermatophytosis	http://purl.obolibrary.org/obo/MONDO_0004678	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	23226#Head BMD (bone mineral density)	http://www.ebi.ac.uk/efo/EFO_0007620	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	30030#Haematocrit percentage	http://www.ebi.ac.uk/efo/EFO_0004348	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#K635#Polyp of colon	http://www.ebi.ac.uk/efo/EFO_1000184	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	25029#Median T2star in caudate (right)	http://www.ebi.ac.uk/efo/EFO_0007849	Irene Lopez, Daniel Suveges	2024-05-15
+AstraZeneca PheWAS Portal		disease	41202#C66#Malignant neoplasm of ureter	http://www.ebi.ac.uk/efo/EFO_0003844	Irene Lopez, Daniel Suveges	2024-05-15


### PR DESCRIPTION
**Same modifications as https://github.com/opentargets/curation/pull/22 but in the correct file this time**

This PR adds mappings for the traits of the AZ Phewas 470k gene/trait associations to the manual curation table.

Even though most of the traits overlap with the previous version (context https://github.com/opentargets/issues/issues/3313), I haven't replaced them in case the trait descriptions are used in subsequent releases.

So these changes add 1723 mappings following the approach described https://github.com/opentargets/issues/issues/3313#issuecomment-2100384117.

- include 11 traits that are only present in the associations extracted from synonymous models
- exclude 256 phenotypes which were duplicates or the inverse phenotypes, which is what the AstraZeneca team do in their portal

The curation spreadsheet is here: https://docs.google.com/spreadsheets/d/1mhavbJejerCeSARev1Xym2ilSyEpoCksPMnWivrzZhI/edit#gid=0
Code to reproduce: https://colab.research.google.com/drive/1l15sHiGpItZrXnvXWwJiyyCW9gQ3KCcT#scrollTo=o6rs5j7g-rKV